### PR TITLE
Send cached state on connect if it exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ type Bridge struct {
 	puppetsLock   sync.Mutex
 	stopping      bool
 	stop          chan struct{}
-	latestState   *imessage.BridgeStatus
+	latestState   imessage.BridgeStatus
 }
 
 type Crypto interface {
@@ -333,7 +333,7 @@ func (bridge *Bridge) SendBridgeStatus(state imessage.BridgeStatus) {
 	if len(state.UserID) == 0 {
 		state.UserID = bridge.user.MXID
 	}
-	bridge.latestState = &state
+	bridge.latestState = state
 	err := bridge.AS.SendWebsocket(&appservice.WebsocketRequest{
 		Command: "bridge_status",
 		Data:    &state,
@@ -368,8 +368,8 @@ func (bridge *Bridge) requestStartSync() {
 func (bridge *Bridge) startWebsocket() {
 	onConnect := func() {
 		// TODO disable this for non-mac connectors once they send bridge status updates themselves
-		if bridge.latestState != nil {
-			go bridge.SendBridgeStatus(*bridge.latestState)
+		if len(bridge.latestState.StateEvent) > 0 {
+			go bridge.SendBridgeStatus(bridge.latestState)
 		} else if bridge.GetConnectorConfig().Platform != "mac-nosip" {
 			go bridge.SendBridgeStatus(imessage.BridgeStatus{StateEvent: BridgeStatusConnected})
 		}

--- a/main.go
+++ b/main.go
@@ -370,7 +370,7 @@ func (bridge *Bridge) startWebsocket() {
 		// TODO disable this for non-mac connectors once they send bridge status updates themselves
 		if bridge.latestState != nil {
 			go bridge.SendBridgeStatus(*bridge.latestState)
-		} else {
+		} else if bridge.GetConnectorConfig().Platform != "mac-nosip" {
 			go bridge.SendBridgeStatus(imessage.BridgeStatus{StateEvent: BridgeStatusConnected})
 		}
 		if bridge.Config.Bridge.Encryption.Appservice && bridge.Crypto != nil {

--- a/main.go
+++ b/main.go
@@ -320,6 +320,7 @@ type StartSyncRequest struct {
 const BridgeStatusConnected = "CONNECTED"
 
 func (bridge *Bridge) SendBridgeStatus(state imessage.BridgeStatus) {
+	bridge.latestState = state
 	bridge.Log.Debugln("Sending bridge status to server")
 	if state.Timestamp == 0 {
 		state.Timestamp = time.Now().Unix()
@@ -333,7 +334,6 @@ func (bridge *Bridge) SendBridgeStatus(state imessage.BridgeStatus) {
 	if len(state.UserID) == 0 {
 		state.UserID = bridge.user.MXID
 	}
-	bridge.latestState = state
 	err := bridge.AS.SendWebsocket(&appservice.WebsocketRequest{
 		Command: "bridge_status",
 		Data:    &state,
@@ -367,7 +367,6 @@ func (bridge *Bridge) requestStartSync() {
 
 func (bridge *Bridge) startWebsocket() {
 	onConnect := func() {
-		// TODO disable this for non-mac connectors once they send bridge status updates themselves
 		if len(bridge.latestState.StateEvent) > 0 {
 			go bridge.SendBridgeStatus(bridge.latestState)
 		} else if bridge.GetConnectorConfig().Platform != "mac-nosip" {


### PR DESCRIPTION
Bridge was sending connected because barcelona-mautrix sends state immediately, which can be before it is connected to Asmux. Initial state is connected by default, so clients think they are logged in when in reality they are not.