### PR TITLE
Add a 15s interval pinger to Barcelona, exits if no pong after 15s

### DIFF
--- a/imessage/mac-nosip/nosip.go
+++ b/imessage/mac-nosip/nosip.go
@@ -106,7 +106,7 @@ func (mac *MacNoSIPConnector) Start() error {
 				// mac did not pong within 15s of last ping
 				if !mac.receivedPing {
 					mac.log.Fatalln("Barcelona did not respond to our last ping. Gotta go!")
-					os.Exit(-1)
+					os.Exit(255)
 				}
 				ipcProc.Send(OutgoingPing, OutgoingPing)
 				mac.receivedPing = false

--- a/imessage/mac-nosip/nosip.go
+++ b/imessage/mac-nosip/nosip.go
@@ -145,12 +145,10 @@ func getLevelFromName(name string) log.Level {
 }
 
 func (mac *MacNoSIPConnector) killPinger() {
-	if len(mac.stopPinger) == 0 {
-		return
+	select {
+	case mac.stopPinger <- true:
+	default:
 	}
-
-	mac.stopPinger <- true
-	mac.stopPinger = nil
 }
 
 func (mac *MacNoSIPConnector) handleIncomingPong(data json.RawMessage) interface{} {

--- a/imessage/mac-nosip/nosip.go
+++ b/imessage/mac-nosip/nosip.go
@@ -59,6 +59,8 @@ func NewMacNoSIPConnector(bridge imessage.Bridge) (imessage.API, error) {
 		log:                 logger,
 		procLog:             processLogger,
 		printPayloadContent: bridge.GetConnectorConfig().LogIPCPayloads,
+		receivedPing:        true,
+		stopPinger:          make(chan bool),
 	}, nil
 }
 

--- a/imessage/mac-nosip/nosip.go
+++ b/imessage/mac-nosip/nosip.go
@@ -96,7 +96,7 @@ func (mac *MacNoSIPConnector) Start() error {
 	ipcProc.SetHandler(IncomingPong, mac.handleIncomingPong)
 
 	mac.killPinger()
-	pinger := time.NewTicker(time.Duration(15000) * time.Millisecond)
+	pinger := time.NewTicker(15 * time.Second)
 	go func() {
 		// set to true initially to start the circuit
 		mac.receivedPing = true

--- a/imessage/mac-nosip/nosip.go
+++ b/imessage/mac-nosip/nosip.go
@@ -60,7 +60,7 @@ func NewMacNoSIPConnector(bridge imessage.Bridge) (imessage.API, error) {
 		log:                 logger,
 		procLog:             processLogger,
 		printPayloadContent: bridge.GetConnectorConfig().LogIPCPayloads,
-		stopPinger:          make(chan bool),
+		stopPinger:          make(chan bool, 8),
 	}, nil
 }
 


### PR DESCRIPTION
Mitigation for Barcelona zombie processes, currently seeing it stop processing events for users after an undefined amount of time. Since it's relatively rare, this is an attempt to nip it in the bud until we can get a better idea of *why* it is hanging.