### PR TITLE
double puppeting: use fi.mau.double_puppet_source and add for redactions

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -228,8 +228,7 @@ func (mx *MatrixHandler) shouldIgnoreEvent(evt *event.Event) bool {
 	if evt.Sender != mx.bridge.user.MXID {
 		return true
 	}
-	isCustomPuppet, ok := evt.Content.Raw["net.maunium.imessage.puppet"].(bool)
-	if ok && isCustomPuppet {
+	if val, ok := evt.Content.Raw[doublePuppetKey].(string); ok && val == doublePuppetValue {
 		return true
 	}
 	return false


### PR DESCRIPTION
Depends on a new mautrix-go version with https://github.com/mautrix/go/pull/50