### PR TITLE
Move read receipt handling to the message processing loop

### DIFF
--- a/imessage.go
+++ b/imessage.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	log "maunium.net/go/maulogger/v2"
-	"maunium.net/go/mautrix/appservice"
 
 	"go.mau.fi/mautrix-imessage/imessage"
 )
@@ -81,27 +80,7 @@ func (imh *iMessageHandler) HandleReadReceipt(rr *imessage.ReadReceipt) {
 	if len(portal.MXID) == 0 {
 		return
 	}
-	var intent *appservice.IntentAPI
-	if rr.IsFromMe {
-		intent = imh.bridge.user.DoublePuppetIntent
-	} else if rr.SenderGUID == rr.ChatGUID {
-		intent = portal.MainIntent()
-	} else {
-		portal.log.Debugfln("Dropping unexpected read receipt %+v", *rr)
-		return
-	}
-	if intent == nil {
-		return
-	}
-	message := imh.bridge.DB.Message.GetLastByGUID(portal.GUID, rr.ReadUpTo)
-	if message == nil {
-		portal.log.Debugfln("Dropping read receipt for %s: message not found in db", rr.ReadUpTo)
-		return
-	}
-	err := intent.MarkRead(portal.MXID, message.MXID)
-	if err != nil {
-		portal.log.Warnln("Failed to send read receipt for %s from %s: %v", message.MXID, intent.UserID)
-	}
+	portal.ReadReceipts <- rr
 }
 
 func (imh *iMessageHandler) HandleTypingNotification(notif *imessage.TypingNotification) {


### PR DESCRIPTION
Similar to https://github.com/mautrix/whatsapp/commit/9e39ce565b480b43cb1675c53e325239e41caae2, this moves read receipts to the same loop as messages to ensure they are only handled after the message they point at.