### PR TITLE
Increase logging of available platforms if the provided platform is invalid

### DIFF
--- a/imessage/interface.go
+++ b/imessage/interface.go
@@ -123,7 +123,7 @@ func NewAPI(bridge Bridge) (API, error) {
 	cfg := bridge.GetConnectorConfig()
 	impl, ok := Implementations[cfg.Platform]
 	if !ok {
-		return nil, fmt.Errorf("no such platform \"%s\"", cfg.Platform)
+		return nil, fmt.Errorf("no such platform \"%s\", available platforms: %+v", cfg.Platform, Implementations)
 	}
 	return impl(bridge)
 }


### PR DESCRIPTION
Debugging mautrix-imessage on an iPhone 7 (iOS 14) with the following with that change, which makes debugging easier:

```
iPhone-7-Red:/private/var/matrix root# ./mautrix-imessage
[Feb 13, 2022 11:43:38] [INFO] Initializing mautrix-imessage 0.1.0+dev.7bf7c23d (Feb 13 2022, 11:16:48)
[Feb 13, 2022 11:43:38] [DEBUG] Initializing database connection
[Feb 13, 2022 11:43:38] [DEBUG] Initializing state store
[Feb 13, 2022 11:43:38] [DEBUG] Initializing Matrix event processor
[Feb 13, 2022 11:43:38] [DEBUG] Initializing Matrix event handler
[Feb 13, 2022 11:43:38] [DEBUG] Initializing iMessage connector
[Feb 13, 2022 11:43:38] [FATAL] Failed to initialize iMessage connector: no such platform "mac-nosip", available: map[android:0x1044ca140 ios:0x1044ca140]
```