### PR TITLE
Wait 60 seconds for file to be sent on iOS (same on MacOS)

### DIFF
--- a/imessage/ios/ipc.go
+++ b/imessage/ios/ipc.go
@@ -407,7 +407,13 @@ func (ios *iOSConnector) SendFile(chatID, filename string, pathOnDisk string, re
 }
 
 func (ios *iOSConnector) SendFileCleanup(sendFileDir string) error {
-	return os.RemoveAll(sendFileDir)
+	go func() {
+		// Random sleep to make sure the message has time to get sent
+		time.Sleep(60 * time.Second)
+		ios.log.Warnln("Deleted temporary file from file transfer, hoping file upload succeeded by now.")
+		_ = os.RemoveAll(sendFileDir)
+	}()
+	return nil
 }
 
 func (ios *iOSConnector) SendTapback(chatID, targetGUID string, targetPart int, tapback imessage.TapbackType, remove bool) (*imessage.SendResponse, error) {

--- a/imessage/ios/ipc.go
+++ b/imessage/ios/ipc.go
@@ -410,7 +410,7 @@ func (ios *iOSConnector) SendFileCleanup(sendFileDir string) error {
 	go func() {
 		// Random sleep to make sure the message has time to get sent
 		time.Sleep(60 * time.Second)
-		ios.log.Warnln("Deleted temporary file from file transfer, hoping file upload succeeded by now.")
+		ios.log.Debugln("Deleted temporary file from file transfer, hoping file upload succeeded by now.")
 		_ = os.RemoveAll(sendFileDir)
 	}()
 	return nil


### PR DESCRIPTION
Fixes https://github.com/open-imcore/barcelona/issues/39. This is how it's done on the MacOS version [here](https://github.com/mautrix/imessage/blob/654ce813f23c26042c5131da5607c3debb2e0b82/imessage/mac/send.go#L190-L198).