### PR TITLE
Update permissions of temporary file because the native imessage agent on iOS doesn't have root permissions

### DIFF
--- a/imessage/interface.go
+++ b/imessage/interface.go
@@ -68,7 +68,7 @@ func SendFilePrepare(filename string, data []byte) (string, string, error) {
 		return "", "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	filePath := filepath.Join(dir, filename)
-	err = ioutil.WriteFile(filePath, data, 0640)
+	err = ioutil.WriteFile(filePath, data, 0644)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to write data to temp file: %w", err)
 	}
@@ -130,9 +130,14 @@ func NewAPI(bridge Bridge) (API, error) {
 
 func TempDir(name string) (string, error) {
 	dir := os.TempDir()
-	err := os.MkdirAll(dir, 0700)
+	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return "", err
 	}
-	return ioutil.TempDir(dir, name)
+	tempDir, dirCreationErr := ioutil.TempDir(dir, name)
+	if dirCreationErr != nil {
+		return "", dirCreationErr
+	}
+	chmodErr := os.Chmod(tempDir, 0755)
+	return tempDir, chmodErr
 }

--- a/imessage/interface.go
+++ b/imessage/interface.go
@@ -29,6 +29,7 @@ import (
 	"maunium.net/go/mautrix/id"
 
 	"go.mau.fi/mautrix-imessage/ipc"
+	"go.mau.fi/mautrix-imessage/imessage/permissions"
 )
 
 var (
@@ -68,7 +69,7 @@ func SendFilePrepare(filename string, data []byte) (string, string, error) {
 		return "", "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	filePath := filepath.Join(dir, filename)
-	err = ioutil.WriteFile(filePath, data, 0644)
+	err = ioutil.WriteFile(filePath, data, permissions.TempFilePermissions())
 	if err != nil {
 		return "", "", fmt.Errorf("failed to write data to temp file: %w", err)
 	}
@@ -130,7 +131,7 @@ func NewAPI(bridge Bridge) (API, error) {
 
 func TempDir(name string) (string, error) {
 	dir := os.TempDir()
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, permissions.TempFolderPermissions())
 	if err != nil {
 		return "", err
 	}
@@ -138,6 +139,6 @@ func TempDir(name string) (string, error) {
 	if dirCreationErr != nil {
 		return "", dirCreationErr
 	}
-	chmodErr := os.Chmod(tempDir, 0755)
+	chmodErr := os.Chmod(tempDir, permissions.TempFolderPermissions())
 	return tempDir, chmodErr
 }

--- a/imessage/permissions/mac-permissions.go
+++ b/imessage/permissions/mac-permissions.go
@@ -14,16 +14,44 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//+build !darwin ios
+//+build darwin,!ios
 
-package main
+package permissions
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"io/fs"
+
+	"github.com/mattn/go-sqlite3"
+
+	"go.mau.fi/mautrix-imessage/imessage"
+	"go.mau.fi/mautrix-imessage/imessage/mac"
 )
 
-func checkMacPermissions() {
-	fmt.Println("--check-permissions is only supported on macOS")
-	os.Exit(2)
+func CheckMacPermissions() {
+	err := mac.CheckPermissions()
+	if err != nil {
+		fmt.Println(err)
+	}
+	if errors.Is(err, imessage.ErrNotLoggedIn) {
+		os.Exit(41)
+	} else if sqliteError := (sqlite3.Error{}); errors.As(err, &sqliteError) {
+		if errors.Is(sqliteError.SystemErrno, os.ErrNotExist) {
+			os.Exit(42)
+		} else if errors.Is(sqliteError.SystemErrno, os.ErrPermission) {
+			os.Exit(43)
+		}
+	} else if err != nil {
+		os.Exit(49)
+	}
+}
+
+func TempFilePermissions() fs.FileMode {
+	return 0640
+}
+
+func TempFolderPermissions() fs.FileMode {
+	return 0700
 }

--- a/imessage/permissions/no-mac.go
+++ b/imessage/permissions/no-mac.go
@@ -14,35 +14,25 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//+build darwin,!ios
+//+build !darwin ios
 
-package main
+package permissions
 
 import (
-	"errors"
 	"fmt"
 	"os"
-
-	"github.com/mattn/go-sqlite3"
-
-	"go.mau.fi/mautrix-imessage/imessage"
-	"go.mau.fi/mautrix-imessage/imessage/mac"
+	"io/fs"
 )
 
-func checkMacPermissions() {
-	err := mac.CheckPermissions()
-	if err != nil {
-		fmt.Println(err)
-	}
-	if errors.Is(err, imessage.ErrNotLoggedIn) {
-		os.Exit(41)
-	} else if sqliteError := (sqlite3.Error{}); errors.As(err, &sqliteError) {
-		if errors.Is(sqliteError.SystemErrno, os.ErrNotExist) {
-			os.Exit(42)
-		} else if errors.Is(sqliteError.SystemErrno, os.ErrPermission) {
-			os.Exit(43)
-		}
-	} else if err != nil {
-		os.Exit(49)
-	}
+func CheckMacPermissions() {
+	fmt.Println("--check-permissions is only supported on macOS")
+	os.Exit(2)
+}
+
+func TempFilePermissions() fs.FileMode {
+	return 0644
+}
+
+func TempFolderPermissions() fs.FileMode {
+	return 0755
 }

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"go.mau.fi/mautrix-imessage/database"
 	"go.mau.fi/mautrix-imessage/database/upgrades"
 	"go.mau.fi/mautrix-imessage/imessage"
+	"go.mau.fi/mautrix-imessage/imessage/permissions"
 	_ "go.mau.fi/mautrix-imessage/imessage/ios"
 	_ "go.mau.fi/mautrix-imessage/imessage/mac-nosip"
 	"go.mau.fi/mautrix-imessage/ipc"
@@ -701,7 +702,7 @@ func main() {
 		fmt.Println(VersionString)
 		return
 	} else if *checkPermissions {
-		checkMacPermissions()
+		permissions.CheckMacPermissions()
 		return
 	}
 


### PR DESCRIPTION
Sorry for filing https://github.com/mautrix/imessage/pull/43, this turned out to be a red herring. After the PR was closed I had no other way of getting this build than setting up the local iMessage go build environment myself, so I went ahead and did that last night.

When testing out, I learned that the deletion of the file isn't the issue, but rather that on iOS the IMFileTransferCenter daemon doesn't run as root user (obviously) and hence isn't able to read the temp folder with `700` permissions created as root. 

After changing both the temp folder permissions, as well as the file permissions sending images from matrix via Barcelona to iMessage works like a charm.