### PR TITLE
message send errors: send success/failure events

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -31,7 +31,9 @@ type BridgeConfig struct {
 	UsernameTemplate    string `yaml:"username_template"`
 	DisplaynameTemplate string `yaml:"displayname_template"`
 
-	DeliveryReceipts bool `yaml:"delivery_receipts"`
+	DeliveryReceipts            bool `yaml:"delivery_receipts"`
+	SendMessageSendStatusEvents bool `yaml:"send_message_send_status_events"`
+	SendErrorNotices            bool `yaml:"send_error_notices"`
 
 	SyncWithCustomPuppets bool    `yaml:"sync_with_custom_puppets"`
 	SyncDirectChatList    bool    `yaml:"sync_direct_chat_list"`

--- a/config/bridge.go
+++ b/config/bridge.go
@@ -35,6 +35,8 @@ type BridgeConfig struct {
 	SendMessageSendStatusEvents bool `yaml:"send_message_send_status_events"`
 	SendErrorNotices            bool `yaml:"send_error_notices"`
 
+	MaxHandleSeconds int `yaml:"max_handle_seconds"`
+
 	SyncWithCustomPuppets bool    `yaml:"sync_with_custom_puppets"`
 	SyncDirectChatList    bool    `yaml:"sync_direct_chat_list"`
 	LoginSharedSecret     string  `yaml:"login_shared_secret"`

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -60,12 +60,11 @@ bridge:
     # Whether or not the bridge should send a read receipt from the bridge bot when a message has been
     # sent to iMessage.
     delivery_receipts: false
-
     # Whether or not the bridge should send the message status as a custom
     # com.beeper.message_send_status event.
     send_message_send_status_events: true
-    # Whether or not the bridge should send error notices when a message fails
-    # to bridge.
+    # Whether or not the bridge should send error notices via m.notice events
+    # when a message fails to bridge.
     send_error_notices: true
 
     # Whether or not to sync with custom puppets to receive EDUs that are not normally sent to appservices.

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -61,6 +61,13 @@ bridge:
     # sent to iMessage.
     delivery_receipts: false
 
+    # Whether or not the bridge should send the message status as a custom
+    # com.beeper.message_send_status event.
+    send_message_send_status_events: true
+    # Whether or not the bridge should send error notices when a message fails
+    # to bridge.
+    send_error_notices: true
+
     # Whether or not to sync with custom puppets to receive EDUs that are not normally sent to appservices.
     sync_with_custom_puppets: false
     # Whether or not to update the m.direct account data event when double puppeting is enabled.

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -67,6 +67,13 @@ bridge:
     # when a message fails to bridge.
     send_error_notices: true
 
+    # The maximum number of seconds between the message arriving at the
+    # homeserver and the bridge attempting to send the message. This can help
+    # prevent messages from being bridged a long time after arriving at the
+    # homeserver which could cause confusion in the chat history on the remote
+    # network. Set to 0 to disable.
+    max_handle_seconds: 10
+
     # Whether or not to sync with custom puppets to receive EDUs that are not normally sent to appservices.
     sync_with_custom_puppets: false
     # Whether or not to update the m.direct account data event when double puppeting is enabled.

--- a/portal.go
+++ b/portal.go
@@ -762,7 +762,7 @@ var EventMessageSendStatus = event.Type{Type: "com.beeper.message_send_status", 
 
 type MessageSendStatusEventContent struct {
 	Network      string          `json:"network"`
-	Relationship event.RelatesTo `json:"relates_to"`
+	Relationship event.RelatesTo `json:"m.relates_to"`
 	Success      bool            `json:"success"`
 	Reason       string          `json:"reason"`
 	Error        string          `json:"error"`

--- a/portal.go
+++ b/portal.go
@@ -461,6 +461,11 @@ func (portal *Portal) GetBasePowerLevels() *event.PowerLevelsEventContent {
 	}
 }
 
+func (portal *Portal) getBridgeInfoStateKey() string {
+	return fmt.Sprintf("%s://%s/%s",
+		bridgeInfoProto, strings.ToLower(portal.Identifier.Service), portal.GUID)
+}
+
 func (portal *Portal) getBridgeInfo() (string, CustomBridgeInfoContent) {
 	bridgeInfo := CustomBridgeInfoContent{
 		BridgeEventContent: event.BridgeEventContent{
@@ -499,9 +504,7 @@ func (portal *Portal) getBridgeInfo() (string, CustomBridgeInfoContent) {
 	} else if portal.bridge.Config.IMessage.Platform == "mac-nosip" {
 		bridgeInfo.Protocol.ID = "imessage-nosip"
 	}
-	bridgeInfoStateKey := fmt.Sprintf("%s://%s/%s",
-		bridgeInfoProto, strings.ToLower(portal.Identifier.Service), portal.GUID)
-	return bridgeInfoStateKey, bridgeInfo
+	return portal.getBridgeInfoStateKey(), bridgeInfo
 }
 
 func (portal *Portal) UpdateBridgeInfo() {
@@ -755,6 +758,19 @@ func (portal *Portal) encryptFile(data []byte, mimeType string) ([]byte, string,
 	return file.Encrypt(data), "application/octet-stream", file
 }
 
+var EventMessageSendStatus = event.Type{Type: "com.beeper.message_send_status", Class: event.MessageEventType}
+
+type MessageSendStatusEventContent struct {
+	Network      string          `json:"network"`
+	Relationship event.RelatesTo `json:"relates_to"`
+	Success      bool            `json:"success"`
+	Reason       string          `json:"reason"`
+	Error        string          `json:"error"`
+	Message      string          `json:"message"`
+	CanRetry     bool            `json:"can_retry"`
+	IsCertain    bool            `json:"is_certain"`
+}
+
 func (portal *Portal) sendErrorMessage(evt *event.Event, err error, isCertain bool, status appservice.MessageSendCheckpointStatus) id.EventID {
 	checkpoint := appservice.NewMessageSendCheckpoint(evt, appservice.StepRemote, status, 0)
 	checkpoint.Info = err.Error()
@@ -764,13 +780,37 @@ func (portal *Portal) sendErrorMessage(evt *event.Event, err error, isCertain bo
 	if isCertain {
 		possibility = "was not"
 	}
-	resp, err := portal.sendMainIntentMessage(event.MessageEventContent{
-		MsgType: event.MsgNotice,
-		Body:    fmt.Sprintf("\u26a0 Your message %s bridged: %v", possibility, err),
-	})
-	if err != nil {
-		portal.log.Warnfln("Failed to send bridging error message:", err)
-		return ""
+
+	var resp *mautrix.RespSendEvent
+	if portal.bridge.Config.Bridge.SendMessageSendStatusEvents {
+		content := MessageSendStatusEventContent{
+			Network: portal.getBridgeInfoStateKey(),
+			Relationship: event.RelatesTo{
+				Type:    event.RelReference,
+				EventID: evt.ID,
+			},
+			Success:   false,
+			Reason:    "m.event_not_handled", // TODO make this more specific eventually
+			Error:     err.Error(),
+			Message:   fmt.Sprintf("Your message %s bridged.", possibility),
+			CanRetry:  false, // TODO change this in the future
+			IsCertain: isCertain,
+		}
+
+		resp, err = portal.sendMessage(portal.MainIntent(), EventMessageSendStatus, content, map[string]interface{}{}, 0)
+		if err != nil {
+			portal.log.Warnfln("Failed to send message send status event:", err)
+			return ""
+		}
+	} else if portal.bridge.Config.Bridge.SendErrorNotices {
+		resp, err = portal.sendMainIntentMessage(event.MessageEventContent{
+			MsgType: event.MsgNotice,
+			Body:    fmt.Sprintf("\u26a0 Your message %s bridged: %v", possibility, err),
+		})
+		if err != nil {
+			portal.log.Warnfln("Failed to send bridging error message:", err)
+			return ""
+		}
 	}
 	return resp.EventID
 }
@@ -796,6 +836,22 @@ func (portal *Portal) sendDeliveryReceipt(eventID id.EventID, sendCheckpoint boo
 			ReportedBy: appservice.ReportedByBridge,
 		}
 		go checkpoint.Send(portal.bridge.AS)
+
+		if portal.bridge.Config.Bridge.SendMessageSendStatusEvents {
+			content := MessageSendStatusEventContent{
+				Network: portal.getBridgeInfoStateKey(),
+				Relationship: event.RelatesTo{
+					Type:    event.RelReference,
+					EventID: eventID,
+				},
+				Success: true,
+			}
+
+			_, err := portal.sendMessage(portal.MainIntent(), EventMessageSendStatus, content, map[string]interface{}{}, 0)
+			if err != nil {
+				portal.log.Warnfln("Failed to send message send status event:", err)
+			}
+		}
 	}
 }
 
@@ -965,6 +1021,27 @@ func (portal *Portal) sendUnsupportedCheckpoint(evt *event.Event, step appservic
 	checkpoint := appservice.NewMessageSendCheckpoint(evt, step, appservice.StatusUnsupported, 0)
 	checkpoint.Info = err.Error()
 	checkpoint.Send(portal.bridge.AS)
+
+	if portal.bridge.Config.Bridge.SendMessageSendStatusEvents {
+		content := MessageSendStatusEventContent{
+			Network: portal.getBridgeInfoStateKey(),
+			Relationship: event.RelatesTo{
+				Type:    event.RelReference,
+				EventID: evt.ID,
+			},
+			Success:   false,
+			Reason:    "com.beeper.unsupported_event",
+			Error:     err.Error(),
+			Message:   "Message type is not supported",
+			CanRetry:  false, // There is no point in retrying a message that is unsupported.
+			IsCertain: true,
+		}
+
+		_, err := portal.sendMessage(portal.MainIntent(), EventMessageSendStatus, content, map[string]interface{}{}, 0)
+		if err != nil {
+			portal.log.Warnfln("Failed to send message send status event:", err)
+		}
+	}
 }
 
 func (portal *Portal) HandleMatrixReaction(evt *event.Event) {

--- a/portal.go
+++ b/portal.go
@@ -898,6 +898,11 @@ func (portal *Portal) HandleMatrixMessage(evt *event.Event) {
 		}
 	}
 
+	if time.Now().Sub(time.Unix(evt.Timestamp, 0)).Seconds() > 10 {
+		portal.log.Debug("It's been over 10 seconds since the message arrived at the homeserver. Will not handle the event.")
+		return
+	}
+
 	var err error
 	var resp *imessage.SendResponse
 	if msg.MsgType == event.MsgText {
@@ -1061,6 +1066,11 @@ func (portal *Portal) HandleMatrixReaction(evt *event.Event) {
 	}
 	portal.log.Debugln("Starting handling of Matrix reaction", evt.ID)
 
+	if time.Now().Sub(time.Unix(evt.Timestamp, 0)).Seconds() > 10 {
+		portal.log.Debug("It's been over 10 seconds since the reaction arrived at the homeserver. Will not handle the event.")
+		return
+	}
+
 	var errorMsg string
 
 	if reaction, ok := evt.Content.Parsed.(*event.ReactionEventContent); !ok || reaction.RelatesTo.Type != event.RelAnnotation {
@@ -1107,6 +1117,11 @@ func (portal *Portal) HandleMatrixReaction(evt *event.Event) {
 func (portal *Portal) HandleMatrixRedaction(evt *event.Event) {
 	if !portal.bridge.IM.Capabilities().SendTapbacks {
 		portal.sendUnsupportedCheckpoint(evt, appservice.StepRemote, errors.New("Bridge does not support any kinds of redactions"))
+		return
+	}
+
+	if time.Now().Sub(time.Unix(evt.Timestamp, 0)).Seconds() > 10 {
+		portal.log.Debug("It's been over 10 seconds since the redaction arrived at the homeserver. Will not handle the event.")
 		return
 	}
 

--- a/portal.go
+++ b/portal.go
@@ -761,14 +761,14 @@ func (portal *Portal) encryptFile(data []byte, mimeType string) ([]byte, string,
 var EventMessageSendStatus = event.Type{Type: "com.beeper.message_send_status", Class: event.MessageEventType}
 
 type MessageSendStatusEventContent struct {
-	Network      string          `json:"network"`
-	Relationship event.RelatesTo `json:"m.relates_to"`
-	Success      bool            `json:"success"`
-	Reason       string          `json:"reason,omitempty"`
-	Error        string          `json:"error,omitempty"`
-	Message      string          `json:"message,omitempty"`
-	CanRetry     bool            `json:"can_retry,omitempty"`
-	IsCertain    bool            `json:"is_certain,omitempty"`
+	Network   string           `json:"network"`
+	RelatesTo *event.RelatesTo `json:"m.relates_to"`
+	Success   bool             `json:"success"`
+	Reason    string           `json:"reason,omitempty"`
+	Error     string           `json:"error,omitempty"`
+	Message   string           `json:"message,omitempty"`
+	CanRetry  bool             `json:"can_retry,omitempty"`
+	IsCertain bool             `json:"is_certain,omitempty"`
 }
 
 func (portal *Portal) sendErrorMessage(evt *event.Event, err error, isCertain bool, status appservice.MessageSendCheckpointStatus) id.EventID {
@@ -795,7 +795,7 @@ func (portal *Portal) sendErrorMessage(evt *event.Event, err error, isCertain bo
 
 		content := MessageSendStatusEventContent{
 			Network: portal.getBridgeInfoStateKey(),
-			Relationship: event.RelatesTo{
+			RelatesTo: &event.RelatesTo{
 				Type:    event.RelReference,
 				EventID: evt.ID,
 			},
@@ -850,7 +850,7 @@ func (portal *Portal) sendDeliveryReceipt(eventID id.EventID, sendCheckpoint boo
 		if portal.bridge.Config.Bridge.SendMessageSendStatusEvents {
 			content := MessageSendStatusEventContent{
 				Network: portal.getBridgeInfoStateKey(),
-				Relationship: event.RelatesTo{
+				RelatesTo: &event.RelatesTo{
 					Type:    event.RelReference,
 					EventID: eventID,
 				},
@@ -1040,7 +1040,7 @@ func (portal *Portal) sendUnsupportedCheckpoint(evt *event.Event, step appservic
 	if portal.bridge.Config.Bridge.SendMessageSendStatusEvents {
 		content := MessageSendStatusEventContent{
 			Network: portal.getBridgeInfoStateKey(),
-			Relationship: event.RelatesTo{
+			RelatesTo: &event.RelatesTo{
 				Type:    event.RelReference,
 				EventID: evt.ID,
 			},

--- a/portal.go
+++ b/portal.go
@@ -764,11 +764,11 @@ type MessageSendStatusEventContent struct {
 	Network      string          `json:"network"`
 	Relationship event.RelatesTo `json:"m.relates_to"`
 	Success      bool            `json:"success"`
-	Reason       string          `json:"reason"`
-	Error        string          `json:"error"`
-	Message      string          `json:"message"`
-	CanRetry     bool            `json:"can_retry"`
-	IsCertain    bool            `json:"is_certain"`
+	Reason       string          `json:"reason,omitempty"`
+	Error        string          `json:"error,omitempty"`
+	Message      string          `json:"message,omitempty"`
+	CanRetry     bool            `json:"can_retry,omitempty"`
+	IsCertain    bool            `json:"is_certain,omitempty"`
 }
 
 func (portal *Portal) sendErrorMessage(evt *event.Event, err error, isCertain bool, status appservice.MessageSendCheckpointStatus) id.EventID {

--- a/portal.go
+++ b/portal.go
@@ -812,7 +812,8 @@ func (portal *Portal) sendErrorMessage(evt *event.Event, err error, isCertain bo
 			portal.log.Warnfln("Failed to send message send status event:", err)
 			return ""
 		}
-	} else if portal.bridge.Config.Bridge.SendErrorNotices {
+	}
+	if portal.bridge.Config.Bridge.SendErrorNotices {
 		resp, err = portal.sendMainIntentMessage(event.MessageEventContent{
 			MsgType: event.MsgNotice,
 			Body:    fmt.Sprintf("\u26a0 Your message %s bridged: %v", possibility, err),

--- a/portal.go
+++ b/portal.go
@@ -900,7 +900,7 @@ func (portal *Portal) HandleMatrixMessage(evt *event.Event) {
 		}
 	}
 
-	if time.Now().Sub(time.Unix(evt.Timestamp, 0)).Seconds() > 10 {
+	if time.Since(time.UnixMilli(evt.Timestamp)) > 10 * time.Second {
 		portal.log.Debug("It's been over 10 seconds since the message arrived at the homeserver. Will not handle the event.")
 		return
 	}
@@ -1068,7 +1068,7 @@ func (portal *Portal) HandleMatrixReaction(evt *event.Event) {
 	}
 	portal.log.Debugln("Starting handling of Matrix reaction", evt.ID)
 
-	if time.Now().Sub(time.Unix(evt.Timestamp, 0)).Seconds() > 10 {
+	if time.Since(time.UnixMilli(evt.Timestamp)) > 10 * time.Second {
 		portal.log.Debug("It's been over 10 seconds since the reaction arrived at the homeserver. Will not handle the event.")
 		return
 	}
@@ -1122,7 +1122,7 @@ func (portal *Portal) HandleMatrixRedaction(evt *event.Event) {
 		return
 	}
 
-	if time.Now().Sub(time.Unix(evt.Timestamp, 0)).Seconds() > 10 {
+	if time.Since(time.UnixMilli(evt.Timestamp)) > 10 * time.Second {
 		portal.log.Debug("It's been over 10 seconds since the redaction arrived at the homeserver. Will not handle the event.")
 		return
 	}


### PR DESCRIPTION
This commit adds the ability to send custom success/failure events when messages succeed or fail to bridge. The event type is `com.beeper.message_send_status`.

To enable, set bridge.send_message_send_status_events to true.

This commit also adds the ability to control whether the error notices are sent in addition to the custom events.

![Screenshot_20220321-133958](https://user-images.githubusercontent.com/16734772/159341938-01fe5817-fb66-47ef-86a1-57e415acb15f.png)
![Screenshot_20220321-134019](https://user-images.githubusercontent.com/16734772/159341945-42b729fe-f926-49fd-b3cb-66f97b0d8062.png)
