### PR TITLE
Support for re-encoding video attachments

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -54,6 +54,8 @@ type BridgeConfig struct {
 	ConvertVideo          struct {
 		Enabled    bool     `yaml:"enabled"`
 		FFMPEGArgs []string `yaml:"ffmpeg_args"`
+		MimeType   string   `yaml:"mime_type"`
+		Extension  string   `yaml:"extension"`
 	} `yaml:"convert_video"`
 
 	FederateRooms bool `yaml:"federate_rooms"`

--- a/config/bridge.go
+++ b/config/bridge.go
@@ -51,6 +51,10 @@ type BridgeConfig struct {
 	MediaViewerSMSMinSize int     `yaml:"media_viewer_sms_min_size"`
 	MediaViewerIMMinSize  int     `yaml:"media_viewer_imessage_min_size"`
 	ConvertHEIF           bool    `yaml:"convert_heif"`
+	ConvertVideo          struct {
+		Enabled    bool     `yaml:"enabled"`
+		FFMPEGArgs []string `yaml:"ffmpeg_args"`
+	} `yaml:"convert_video"`
 
 	FederateRooms bool `yaml:"federate_rooms"`
 

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -110,6 +110,14 @@ bridge:
     # Should we convert heif images to jpeg before re-uploading? This increases
     # compatibility, but adds generation loss (reduces quality).
     convert_heif: true
+    # Modern Apple devices tend to use h265 encoding for video, which is a licensed standard and therefore not
+    # supported by most major browsers. If enabled, all video attachments will be converted according to the
+    # ffmpeg args.
+    convert_video:
+        enabled: true
+        # Convert to webm format (open and widely supported standard) at decent quality while retaining original
+        # audio. Modify these args to do whatever encoding/quality you want. 
+        ffmpeg_args: ["-c:v", "libvpx-vp9", "-crf", "30"]
 
     # The prefix for commands.
     command_prefix: "!im"

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -114,7 +114,7 @@ bridge:
     # supported by most major browsers. If enabled, all video attachments will be converted according to the
     # ffmpeg args.
     convert_video:
-        enabled: true
+        enabled: false
         # Convert to h264 format (supported by all major browsers) at decent quality while retaining original
         # audio. Modify these args to do whatever encoding/quality you want. 
         ffmpeg_args: ["-c:v", "libx264", "-preset", "faster", "-crf", "22", "-c:a", "copy"]

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -115,9 +115,11 @@ bridge:
     # ffmpeg args.
     convert_video:
         enabled: true
-        # Convert to webm format (open and widely supported standard) at decent quality while retaining original
+        # Convert to h264 format (supported by all major browsers) at decent quality while retaining original
         # audio. Modify these args to do whatever encoding/quality you want. 
-        ffmpeg_args: ["-c:v", "libvpx-vp9", "-crf", "30"]
+        ffmpeg_args: ["-c:v", "libx264", "-preset", "faster", "-crf", "22", "-c:a", "copy"]
+        extension: "mp4"
+        mime_type: "video/mp4"
 
     # The prefix for commands.
     command_prefix: "!im"

--- a/portal.go
+++ b/portal.go
@@ -1350,12 +1350,13 @@ func (portal *Portal) handleIMAttachment(msg *imessage.Message, attach *imessage
 		}
 	}
 
-	if portal.Config.Bridge.ConvertVideo.Enabled && mimeType == "video/quicktime" {
-		webm, err := ffmpeg.ConvertBytes(data, ".webm", []string{}, portal.Config.Bridge.ConvertVideo.FFMPEGArgs, "video/quicktime")
+	if portal.bridge.Config.Bridge.ConvertVideo.Enabled && mimeType == "video/quicktime" {
+		conv := portal.bridge.Config.Bridge.ConvertVideo
+		convertedData, err := ffmpeg.ConvertBytes(data, "."+conv.Extension, []string{}, conv.FFMPEGArgs, "video/quicktime")
 		if err == nil {
-			mimeType = "video/webm"
-			fileName += ".webm"
-			data = webm
+			mimeType = conv.MimeType
+			fileName += "." + conv.Extension
+			data = convertedData
 		} else {
 			portal.log.Errorf("Failed to convert quicktime video to webm: %v - sending without conversion", err)
 		}

--- a/portal.go
+++ b/portal.go
@@ -1350,6 +1350,17 @@ func (portal *Portal) handleIMAttachment(msg *imessage.Message, attach *imessage
 		}
 	}
 
+	if portal.Config.Bridge.ConvertVideo.Enabled && mimeType == "video/quicktime" {
+		webm, err := ffmpeg.ConvertBytes(data, ".webm", []string{}, portal.Config.Bridge.ConvertVideo.FFMPEGArgs, "video/quicktime")
+		if err == nil {
+			mimeType = "video/webm"
+			fileName += ".webm"
+			data = webm
+		} else {
+			portal.log.Errorf("Failed to convert quicktime video to webm: %v - sending without conversion", err)
+		}
+	}
+
 	data, uploadMime, uploadInfo := portal.encryptFile(data, mimeType)
 	uploadResp, err := intent.UploadBytes(data, uploadMime)
 	if err != nil {


### PR DESCRIPTION
Modern Apple devices like to h265 encoding when sending video, which makes sense as it's modern and space efficient while retaining high quality.

Unfortunately, h265 has a ton of licensing red-tape around it, and the result is basically no devices nor browsers, other than Apple's, have any support for it.

This is pretty annoying if you use a web-based Matrix client (e.g. Element) as you end up needing to use an external video player like VLC to view videos, rather than in app.

This PR adds the ability to automatically re-encode video attachments into whatever `ffmpeg` on the bridge host machine supports.

The functionality is disabled by default in the `example-config.yaml` and I included example args for `x264` re-encoding that runs pretty quick on my Monterey VM. I expect that it would work significantly better on real hardware with physical codec support. I was originally going to do `webm`, since it's "truly open", but it was a bit unreasonably slow no matter how I configured it.