### PR TITLE
BRI-3497: Upgrade or tombstone SMS rooms when chat merging is enabled

### DIFF
--- a/imessage/interface.go
+++ b/imessage/interface.go
@@ -120,7 +120,8 @@ type PlatformConfig struct {
 
 	PingInterval int64 `yaml:"ping_interval_seconds"`
 
-	ChatMerging bool `yaml:"chat_merging"`
+	ChatMerging       bool `yaml:"chat_merging"`
+	TombstoneOldRooms bool `yaml:"tombstone_old_rooms"`
 }
 
 func (pc *PlatformConfig) BridgeName() string {

--- a/main.go
+++ b/main.go
@@ -641,9 +641,10 @@ func (bridge *Bridge) StartupSync() {
 		removed := portal.CleanupIfEmpty(true)
 		if !removed && len(portal.MXID) > 0 {
 			portal.log.Infoln("Syncing portal (startup sync, existing portal)")
+			merged := portal.TombstoneOrReIDIfNeeded()
 			portal.Sync(true)
 			alreadySynced[portal.GUID] = true
-			if forceUpdateBridgeInfo {
+			if forceUpdateBridgeInfo || merged {
 				portal.UpdateBridgeInfo()
 			}
 		}

--- a/portal.go
+++ b/portal.go
@@ -236,6 +236,11 @@ func (portal *Portal) ensureUserInvited(user *User) {
 }
 
 func (portal *Portal) Sync(backfill bool) {
+	if portal.Identifier.Service == "SMS" && portal.bridge.Config.IMessage.TombstoneOldRooms && portal.bridge.Config.IMessage.ChatMerging {
+		portal.log.Infoln("Skipping SMS chat as it has been merged into iMessage")
+		return
+	}
+
 	if len(portal.MXID) == 0 {
 		portal.log.Infoln("Creating Matrix room due to sync")
 		err := portal.CreateMatrixRoom(nil, nil)


### PR DESCRIPTION
This PR enables the bridge to convert SMS rooms to iMessage rooms in the event they have no iMessage counterpart, and tombstones SMS rooms that do have an iMessage counterpart. This is only enabled when `imessage.tombstone_old_rooms` is set to `true`.