### PR TITLE
Make convertRichLinkToBeeper null-safe

### DIFF
--- a/urlpreview.go
+++ b/urlpreview.go
@@ -132,57 +132,58 @@ func (portal *Portal) convertRichLinkToBeeper(richLink *imessage.RichLink) (outp
 	}
 
 	if richLink.Image != nil {
-		output.ImageWidth = int(richLink.Image.Size.Width)
-		output.ImageHeight = int(richLink.Image.Size.Height)
+		if richLink.Image.Size != nil {
+			output.ImageWidth = int(richLink.Image.Size.Width)
+			output.ImageHeight = int(richLink.Image.Size.Height)
+		}
 		output.ImageType = richLink.ItemType
 
-		thumbnailData := richLink.Image.Source.Data
-		if thumbnailData == nil {
-			if url := richLink.Image.Source.URL; url != "" {
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-				defer cancel()
-				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-				if err != nil {
-					return
+		if richLink.Image.Source != nil {
+			thumbnailData := richLink.Image.Source.Data
+			if thumbnailData == nil {
+				if url := richLink.Image.Source.URL; url != "" {
+					ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+					defer cancel()
+					req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+					if err != nil {
+						return
+					}
+					thumbnailData, _ = ioutil.ReadAll(req.Body)
 				}
-				thumbnailData, _ = ioutil.ReadAll(req.Body)
 			}
-		}
 
-		if thumbnailData == nil {
-			return
-		}
-
-		if output.ImageHeight == 0 || output.ImageWidth == 0 {
-			src, _, err := image.Decode(bytes.NewReader(thumbnailData))
-			if err == nil {
-				imageBounds := src.Bounds()
-				output.ImageWidth, output.ImageHeight = imageBounds.Max.X, imageBounds.Max.Y
+			if output.ImageHeight == 0 || output.ImageWidth == 0 {
+				src, _, err := image.Decode(bytes.NewReader(thumbnailData))
+				if err == nil {
+					imageBounds := src.Bounds()
+					output.ImageWidth, output.ImageHeight = imageBounds.Max.X, imageBounds.Max.Y
+				}
 			}
-		}
 
-		output.ImageSize = len(thumbnailData)
-		if output.ImageType == "" {
-			output.ImageType = http.DetectContentType(thumbnailData)
-		}
+			output.ImageSize = len(thumbnailData)
+			if output.ImageType == "" {
+				output.ImageType = http.DetectContentType(thumbnailData)
+			}
 
-		uploadData, uploadMime := thumbnailData, output.ImageType
-		if portal.Encrypted {
-			crypto := attachment.NewEncryptedFile()
-			crypto.EncryptInPlace(uploadData)
-			uploadMime = "application/octet-stream"
-			output.ImageEncryption = &event.EncryptedFileInfo{EncryptedFile: *crypto}
-		}
-		resp, err := portal.bridge.Bot.UploadBytes(uploadData, uploadMime)
-		if err != nil {
-			portal.log.Warnfln("Failed to reupload thumbnail for link preview: %v", err)
-		} else {
-			if output.ImageEncryption != nil {
-				output.ImageEncryption.URL = resp.ContentURI.CUString()
+			uploadData, uploadMime := thumbnailData, output.ImageType
+			if portal.Encrypted {
+				crypto := attachment.NewEncryptedFile()
+				crypto.EncryptInPlace(uploadData)
+				uploadMime = "application/octet-stream"
+				output.ImageEncryption = &event.EncryptedFileInfo{EncryptedFile: *crypto}
+			}
+			resp, err := portal.bridge.Bot.UploadBytes(uploadData, uploadMime)
+			if err != nil {
+				portal.log.Warnfln("Failed to reupload thumbnail for link preview: %v", err)
 			} else {
-				output.ImageURL = resp.ContentURI.CUString()
+				if output.ImageEncryption != nil {
+					output.ImageEncryption.URL = resp.ContentURI.CUString()
+				} else {
+					output.ImageURL = resp.ContentURI.CUString()
+				}
 			}
 		}
+
 	}
 
 	return


### PR DESCRIPTION
This modifies the convertRichLinkToBeeper function to take into account the nullability of more parts of richlink metadata.