### PR TITLE
Carry over version property when upgrading config

### DIFF
--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -27,6 +27,8 @@ func DoUpgrade(helper *up.Helper) {
 	}
 	bridgeconfig.Upgrader.DoUpgrade(helper)
 
+	helper.Copy(up.Int, "revision")
+
 	helper.Copy(up.Str, "logging", "directory")
 	helper.Copy(up.Str|up.Null, "logging", "file_name_format")
 	helper.Copy(up.Str|up.Timestamp, "logging", "file_date_format")
@@ -133,4 +135,5 @@ var SpacedBlocks = [][]string{
 	{"bridge", "encryption"},
 	{"bridge", "relay"},
 	{"logging"},
+	{"revision"},
 }

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -236,3 +236,6 @@ logging:
     print_level: debug
     print_json: false
     file_json: false
+
+# This may be used by external config managers. mautrix-imessage does not read it, but will carry it across configuration migrations.
+revision: 0


### PR DESCRIPTION
Beeper uses the revision property internally on our cloud iMessage bridges to track the version deployed to a given bridge. This modifies the upgrade code to carry this over, and explains its purpose in the example-config.yaml