### PR TITLE
Add name_override column to puppet to persist start_dm displaynames

### DIFF
--- a/database/puppet.go
+++ b/database/puppet.go
@@ -38,7 +38,7 @@ func (pq *PuppetQuery) New() *Puppet {
 }
 
 func (pq *PuppetQuery) GetAll() (puppets []*Puppet) {
-	rows, err := pq.db.Query("SELECT id, displayname, avatar_hash, avatar_url FROM puppet")
+	rows, err := pq.db.Query("SELECT id, displayname, avatar_hash, avatar_url, name_override FROM puppet")
 	if err != nil || rows == nil {
 		return nil
 	}
@@ -50,7 +50,7 @@ func (pq *PuppetQuery) GetAll() (puppets []*Puppet) {
 }
 
 func (pq *PuppetQuery) Get(id string) *Puppet {
-	row := pq.db.QueryRow("SELECT id, displayname, avatar_hash, avatar_url FROM puppet WHERE id=$1", id)
+	row := pq.db.QueryRow("SELECT id, displayname, avatar_hash, avatar_url, name_override FROM puppet WHERE id=$1", id)
 	if row == nil {
 		return nil
 	}
@@ -61,10 +61,11 @@ type Puppet struct {
 	db  *Database
 	log log.Logger
 
-	ID          string
-	Displayname string
-	AvatarHash  *[32]byte
-	AvatarURL   id.ContentURI
+	ID           string
+	Displayname  string
+	AvatarHash   *[32]byte
+	AvatarURL    id.ContentURI
+	NameOverride string
 }
 
 func (puppet *Puppet) avatarHashSlice() []byte {
@@ -77,7 +78,7 @@ func (puppet *Puppet) avatarHashSlice() []byte {
 func (puppet *Puppet) Scan(row dbutil.Scannable) *Puppet {
 	var avatarURL sql.NullString
 	var avatarHashSlice []byte
-	err := row.Scan(&puppet.ID, &puppet.Displayname, &avatarHashSlice, &avatarURL)
+	err := row.Scan(&puppet.ID, &puppet.Displayname, &avatarHashSlice, &avatarURL, &puppet.NameOverride)
 	if err != nil {
 		if err != sql.ErrNoRows {
 			puppet.log.Errorln("Database scan failed:", err)
@@ -94,16 +95,16 @@ func (puppet *Puppet) Scan(row dbutil.Scannable) *Puppet {
 }
 
 func (puppet *Puppet) Insert() {
-	_, err := puppet.db.Exec("INSERT INTO puppet (id, displayname, avatar_hash, avatar_url) VALUES ($1, $2, $3, $4)",
-		puppet.ID, puppet.Displayname, puppet.avatarHashSlice(), puppet.AvatarURL.String())
+	_, err := puppet.db.Exec("INSERT INTO puppet (id, displayname, avatar_hash, avatar_url, name_override) VALUES ($1, $2, $3, $4, $5)",
+		puppet.ID, puppet.Displayname, puppet.avatarHashSlice(), puppet.AvatarURL.String(), puppet.NameOverride)
 	if err != nil {
 		puppet.log.Warnfln("Failed to insert %s: %v", puppet.ID, err)
 	}
 }
 
 func (puppet *Puppet) Update() {
-	_, err := puppet.db.Exec("UPDATE puppet SET displayname=$1, avatar_hash=$2, avatar_url=$3 WHERE id=$4",
-		puppet.Displayname, puppet.avatarHashSlice(), puppet.AvatarURL.String(), puppet.ID)
+	_, err := puppet.db.Exec("UPDATE puppet SET displayname=$1, avatar_hash=$2, avatar_url=$3, name_override=$4 WHERE id=$5",
+		puppet.Displayname, puppet.avatarHashSlice(), puppet.AvatarURL.String(), puppet.NameOverride, puppet.ID)
 	if err != nil {
 		puppet.log.Warnfln("Failed to update %s: %v", puppet.ID, err)
 	}

--- a/database/upgrades/13-displayname-override.sql
+++ b/database/upgrades/13-displayname-override.sql
@@ -1,0 +1,2 @@
+-- v13: Add a separate column for tracking
+ALTER TABLE "puppet" ADD COLUMN name_override TEXT NOT NULL DEFAULT '';

--- a/portal.go
+++ b/portal.go
@@ -613,9 +613,11 @@ func (portal *Portal) CreateMatrixRoom(chatInfo *imessage.ChatInfo, profileOverr
 		puppet := portal.bridge.GetPuppetByLocalID(portal.Identifier.LocalID)
 		puppet.Sync()
 		if profileOverride != nil {
+			portal.Name = profileOverride.Displayname
 			puppet.SyncWithProfileOverride(*profileOverride)
+		} else {
+			portal.Name = puppet.Displayname
 		}
-		portal.Name = puppet.Displayname
 		portal.AvatarURL = puppet.AvatarURL
 		portal.AvatarHash = puppet.AvatarHash
 	} else {

--- a/puppet.go
+++ b/puppet.go
@@ -149,6 +149,8 @@ type Puppet struct {
 
 	MXID   id.UserID
 	Intent *appservice.IntentAPI
+
+	NameOverride string
 }
 
 var _ bridge.Ghost = (*Puppet)(nil)
@@ -183,6 +185,9 @@ func (puppet *Puppet) UpdateName(contact *imessage.Contact) bool {
 }
 
 func (puppet *Puppet) UpdateNameDirect(name string) bool {
+	if len(puppet.NameOverride) != 0 {
+		name = puppet.NameOverride
+	}
 	if len(name) == 0 {
 		return false
 	}
@@ -320,6 +325,8 @@ func (puppet *Puppet) backgroundAvatarUpdate(url string) {
 func (puppet *Puppet) SyncWithProfileOverride(override ProfileOverride) {
 	if len(override.Displayname) > 0 {
 		puppet.UpdateNameDirect(override.Displayname)
+		puppet.NameOverride = override.Displayname
+		puppet.Update()
 	}
 	if len(override.PhotoURL) > 0 {
 		go puppet.backgroundAvatarUpdate(override.PhotoURL)


### PR DESCRIPTION
Fixes a series of issues where rooms named via the `start_dm` endpoint are renamed during subsequent init syncs