### PR TITLE
Add support for sending message metadata

### DIFF
--- a/imessage/interface.go
+++ b/imessage/interface.go
@@ -54,8 +54,8 @@ type API interface {
 	ResolveIdentifier(identifier string) (string, error)
 	PrepareDM(guid string) error
 
-	SendMessage(chatID, text string, replyTo string, replyToPart int, richLink *RichLink) (*SendResponse, error)
-	SendFile(chatID, text, filename string, pathOnDisk string, replyTo string, replyToPart int, mimeType string, voiceMemo bool) (*SendResponse, error)
+	SendMessage(chatID, text string, replyTo string, replyToPart int, richLink *RichLink, metadata MessageMetadata) (*SendResponse, error)
+	SendFile(chatID, text, filename string, pathOnDisk string, replyTo string, replyToPart int, mimeType string, voiceMemo bool, metadata MessageMetadata) (*SendResponse, error)
 	SendFileCleanup(sendFileDir string)
 	SendTapback(chatID, targetGUID string, targetPart int, tapback TapbackType, remove bool) (*SendResponse, error)
 	SendReadReceipt(chatID, readUpTo string) error

--- a/imessage/ios/ipc.go
+++ b/imessage/ios/ipc.go
@@ -410,7 +410,7 @@ func (ios *iOSConnector) GetGroupAvatar(chatID string) (*imessage.Attachment, er
 	return &resp, err
 }
 
-func (ios *iOSConnector) SendMessage(chatID, text string, replyTo string, replyToPart int, richLink *imessage.RichLink) (*imessage.SendResponse, error) {
+func (ios *iOSConnector) SendMessage(chatID, text string, replyTo string, replyToPart int, richLink *imessage.RichLink, metadata imessage.MessageMetadata) (*imessage.SendResponse, error) {
 	var resp imessage.SendResponse
 	err := ios.IPC.Request(context.Background(), ReqSendMessage, &SendMessageRequest{
 		ChatGUID:    chatID,
@@ -418,6 +418,7 @@ func (ios *iOSConnector) SendMessage(chatID, text string, replyTo string, replyT
 		ReplyTo:     replyTo,
 		ReplyToPart: replyToPart,
 		RichLink:    richLink,
+		Metadata:    metadata,
 	}, &resp)
 	if err == nil {
 		resp.Time = floatToTime(resp.UnixTime)
@@ -428,7 +429,7 @@ func (ios *iOSConnector) SendMessage(chatID, text string, replyTo string, replyT
 	return &resp, err
 }
 
-func (ios *iOSConnector) SendFile(chatID, text, filename string, pathOnDisk string, replyTo string, replyToPart int, mimeType string, voiceMemo bool) (*imessage.SendResponse, error) {
+func (ios *iOSConnector) SendFile(chatID, text, filename string, pathOnDisk string, replyTo string, replyToPart int, mimeType string, voiceMemo bool, metadata imessage.MessageMetadata) (*imessage.SendResponse, error) {
 	var resp imessage.SendResponse
 	err := ios.IPC.Request(context.Background(), ReqSendMedia, &SendMediaRequest{
 		ChatGUID: chatID,
@@ -441,6 +442,7 @@ func (ios *iOSConnector) SendFile(chatID, text, filename string, pathOnDisk stri
 		ReplyTo:        replyTo,
 		ReplyToPart:    replyToPart,
 		IsAudioMessage: voiceMemo,
+		Metadata:       metadata,
 	}, &resp)
 	if err == nil {
 		resp.Time = floatToTime(resp.UnixTime)

--- a/imessage/ios/ipc.md
+++ b/imessage/ios/ipc.md
@@ -112,6 +112,7 @@ Another error response:
   * `target_guid` (str) - The target message ID
   * `target_part` (int) - The target message part index
   * `type` (int) - The type of tapback to send
+  * `metadata` (any) - Metadata to send with the message. Pass any valid JSON
   * Response should contain the sent tapback `guid` and `timestamp`
   * Removing tapbacks is done by sending a 300x type instead of 200x (same as iMessage internally)
 * Send a read receipt (request type `send_read_receipt`)
@@ -200,6 +201,7 @@ Another error response:
     * For avatar changes, 1 = set avatar, 2 = remove avatar
   * `target_guid` (str, optional) - For member change messages, the user identifier of the user being changed.
   * `new_group_title` (str, optional) - New name for group when the message was a group name change
+  * `metadata` (any) - Metadata sent with the message. Any valid JSON may be present here.
 * Incoming read receipts (request type `read_receipt`)
   * `sender_guid` (str) - the user who sent the read receipt. Not required if `is_from_me` is true.
   * `is_from_me` (bool) - True if the read receipt is from the local user (e.g. from another device).

--- a/imessage/ios/requests.go
+++ b/imessage/ios/requests.go
@@ -41,20 +41,22 @@ const (
 )
 
 type SendMessageRequest struct {
-	ChatGUID    string             `json:"chat_guid"`
-	Text        string             `json:"text"`
-	ReplyTo     string             `json:"reply_to"`
-	ReplyToPart int                `json:"reply_to_part"`
-	RichLink    *imessage.RichLink `json:"rich_link,omitempty"`
+	ChatGUID    string                   `json:"chat_guid"`
+	Text        string                   `json:"text"`
+	ReplyTo     string                   `json:"reply_to"`
+	ReplyToPart int                      `json:"reply_to_part"`
+	RichLink    *imessage.RichLink       `json:"rich_link,omitempty"`
+	Metadata    imessage.MessageMetadata `json:"metadata,omitempty"`
 }
 
 type SendMediaRequest struct {
 	ChatGUID string `json:"chat_guid"`
 	Text     string `json:"text"`
 	imessage.Attachment
-	ReplyTo        string `json:"reply_to"`
-	ReplyToPart    int    `json:"reply_to_part"`
-	IsAudioMessage bool   `json:"is_audio_message"`
+	ReplyTo        string                   `json:"reply_to"`
+	ReplyToPart    int                      `json:"reply_to_part"`
+	IsAudioMessage bool                     `json:"is_audio_message"`
+	Metadata       imessage.MessageMetadata `json:"metadata,omitempty"`
 }
 
 type SendTapbackRequest struct {

--- a/imessage/mac/send.go
+++ b/imessage/mac/send.go
@@ -176,11 +176,11 @@ func (mac *macOSDatabase) sendMessageWithRetry(script, fallbackScript1, fallback
 	return err
 }
 
-func (mac *macOSDatabase) SendMessage(chatID, text string, replyTo string, replyToPart int, _ *imessage.RichLink) (*imessage.SendResponse, error) {
+func (mac *macOSDatabase) SendMessage(chatID, text string, replyTo string, replyToPart int, _ *imessage.RichLink, metadata imessage.MessageMetadata) (*imessage.SendResponse, error) {
 	return nil, mac.sendMessageWithRetry(sendMessage, sendMessageWithService, sendMessageBuddy, imessage.ParseIdentifier(chatID), text)
 }
 
-func (mac *macOSDatabase) SendFile(chatID, text, filename string, pathOnDisk string, replyTo string, replyToPart int, mimeType string, voiceMemo bool) (*imessage.SendResponse, error) {
+func (mac *macOSDatabase) SendFile(chatID, text, filename string, pathOnDisk string, replyTo string, replyToPart int, mimeType string, voiceMemo bool, metadata imessage.MessageMetadata) (*imessage.SendResponse, error) {
 	if voiceMemo {
 		mac.log.Warn("received a request to send a file as a voice memo, but mac does not support this. sending as regular attachment.")
 	}

--- a/imessage/struct.go
+++ b/imessage/struct.go
@@ -69,7 +69,11 @@ type Message struct {
 	NewGroupName    string          `json:"new_group_title,omitempty"`
 
 	RichLink *RichLink `json:"rich_link,omitempty"`
+
+	Metadata MessageMetadata `json:"metadata,omitempty"`
 }
+
+type MessageMetadata map[string]interface{}
 
 func (msg *Message) SenderText() string {
 	if msg.IsFromMe {


### PR DESCRIPTION
This implements support for sending and receiving client-provided metadata with messages when using the `mac-nosip` driver