### PR TITLE
Allow profile overrides to specify an mxc in lieu of an http

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -99,7 +99,7 @@ func (mx *WebsocketCommandHandler) handleWSSyncProxyError(cmd appservice.Websock
 type ProfileOverride struct {
 	Displayname string `json:"displayname,omitempty"`
 	PhotoURL    string `json:"photo_url,omitempty"`
-	PhotoMXC    string `json:"photo_mxc,omitempty"`
+	PhotoMXC    id.ContentURI `json:"photo_mxc,omitempty"`
 }
 
 type EditGhostRequest struct {

--- a/matrix.go
+++ b/matrix.go
@@ -99,6 +99,7 @@ func (mx *WebsocketCommandHandler) handleWSSyncProxyError(cmd appservice.Websock
 type ProfileOverride struct {
 	Displayname string `json:"displayname,omitempty"`
 	PhotoURL    string `json:"photo_url,omitempty"`
+	PhotoMXC    string `json:"photo_mxc,omitempty"`
 }
 
 type EditGhostRequest struct {
@@ -138,13 +139,7 @@ func (mx *WebsocketCommandHandler) handleWSEditGhost(cmd appservice.WebsocketCom
 		puppet.Sync()
 	} else {
 		puppet.log.Debugfln("Updating profile with %+v", req.ProfileOverride)
-		if req.Displayname != "" {
-			puppet.NameOverridden = true
-			puppet.UpdateNameDirect(req.Displayname)
-		}
-		if req.PhotoURL != "" {
-			go puppet.backgroundAvatarUpdate(req.PhotoURL)
-		}
+		puppet.SyncWithProfileOverride(req.ProfileOverride)
 	}
 	return true, struct{}{}
 }

--- a/puppet.go
+++ b/puppet.go
@@ -342,13 +342,8 @@ func (puppet *Puppet) SyncWithProfileOverride(override ProfileOverride) {
 	}
 	if len(override.PhotoURL) > 0 {
 		go puppet.backgroundAvatarUpdate(override.PhotoURL)
-	} else if len(override.PhotoMXC) > 0 {
-		mxc, err := id.ParseContentURI(override.PhotoMXC)
-		if err != nil {
-			puppet.log.Warnfln("Failed to parse mxc %s: %v", override.PhotoMXC, err)
-		} else {
-			go puppet.UpdateAvatarFromMXC(mxc)
-		}
+	} else if !override.PhotoMXC.IsEmpty() {
+		puppet.UpdateAvatarFromMXC(override.PhotoMXC)
 	}
 }
 

--- a/puppet.go
+++ b/puppet.go
@@ -233,17 +233,21 @@ func (puppet *Puppet) UpdateAvatarFromBytes(avatar []byte) bool {
 			puppet.log.Warnln("Failed to upload avatar:", err)
 			return false
 		}
-		puppet.AvatarURL = resp.ContentURI
-		err = puppet.Intent.SetAvatarURL(puppet.AvatarURL)
-		if err != nil {
-			puppet.AvatarHash = nil
-			puppet.log.Warnln("Failed to set avatar:", err)
-			return false
-		}
-		go puppet.updatePortalAvatar()
-		return true
+		return puppet.UpdateAvatarFromMXC(resp.ContentURI)
 	}
 	return false
+}
+
+func (puppet *Puppet) UpdateAvatarFromMXC(mxc id.ContentURI) bool {
+	puppet.AvatarURL = mxc
+	err := puppet.Intent.SetAvatarURL(puppet.AvatarURL)
+	if err != nil {
+		puppet.AvatarHash = nil
+		puppet.log.Warnln("Failed to set avatar:", err)
+		return false
+	}
+	go puppet.updatePortalAvatar()
+	return true
 }
 
 func applyMeta(portal *Portal, meta func(portal *Portal)) {
@@ -338,6 +342,13 @@ func (puppet *Puppet) SyncWithProfileOverride(override ProfileOverride) {
 	}
 	if len(override.PhotoURL) > 0 {
 		go puppet.backgroundAvatarUpdate(override.PhotoURL)
+	} else if len(override.PhotoMXC) > 0 {
+		mxc, err := id.ParseContentURI(override.PhotoMXC)
+		if err != nil {
+			puppet.log.Warnfln("Failed to parse mxc %s: %v", override.PhotoMXC, err)
+		} else {
+			go puppet.UpdateAvatarFromMXC(mxc)
+		}
 	}
 }
 


### PR DESCRIPTION
Profile override only accepts a photo_url, meaning the photo will be downloaded and uploaded to the media repo for the bridge. This allows profile overrides to specify a photo_mxc which is directly set on the room without reuploading.