### PR TITLE
Replace photo_mxc with checking for the mxc scheme

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -99,7 +99,6 @@ func (mx *WebsocketCommandHandler) handleWSSyncProxyError(cmd appservice.Websock
 type ProfileOverride struct {
 	Displayname string `json:"displayname,omitempty"`
 	PhotoURL    string `json:"photo_url,omitempty"`
-	PhotoMXC    id.ContentURI `json:"photo_mxc,omitempty"`
 }
 
 type EditGhostRequest struct {

--- a/puppet.go
+++ b/puppet.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -337,22 +336,13 @@ func (puppet *Puppet) backgroundAvatarUpdate(url string) {
 	}
 }
 
-func (puppet *Puppet) syncAvatarWithRawURL(rawUrl string) {
-	photoUrl, err := url.Parse(rawUrl)
+func (puppet *Puppet) syncAvatarWithRawURL(rawURL string) {
+	mxc, err := id.ParseContentURI(rawURL)
 	if err != nil {
-		puppet.log.Warnfln("Error while parsing photo url %s: %v", rawUrl, err)
+		go puppet.backgroundAvatarUpdate(rawURL)
 		return
 	}
-	if photoUrl.Scheme == "mxc" {
-		mxc, err := id.ParseContentURI(rawUrl)
-		if err != nil {
-			puppet.log.Warnfln("Error while parsing mxc %s: %v", photoUrl, err)
-			return
-		}
-		puppet.UpdateAvatarFromMXC(mxc)
-	} else {
-		go puppet.backgroundAvatarUpdate(rawUrl)
-	}
+	puppet.UpdateAvatarFromMXC(mxc)
 }
 
 func (puppet *Puppet) SyncWithProfileOverride(override ProfileOverride) {


### PR DESCRIPTION
Client devs have requested photo_mxc be merged into photo_url and that the bridge set the MXC directly if the photo_url has an mxc scheme.