### PR TITLE
Increment ExpectedBridgeInfoVersion to rebuild m.bridge events

### DIFF
--- a/database/kvstore.go
+++ b/database/kvstore.go
@@ -33,7 +33,7 @@ const (
 	KVSendStatusStart   = "com.beeper.send_status_start"
 	KVBridgeInfoVersion = "bridge_info_version"
 
-	ExpectedBridgeInfoVersion = ""
+	ExpectedBridgeInfoVersion = "1"
 )
 
 func (kvq *KeyValueQuery) Get(key string) (value string) {


### PR DESCRIPTION
The logic for updating m.bridge events is not firing for certain rooms, meaning those rooms are missing `com.beeper.send_status_start` - incrementing ExpectedBridgeInfoVersion forces mautrix-imessage to update the m.bridge even if it thinks it doesn't need to.