### PR TITLE
Fix bridging video attachments from matrix clients that didn't include an extension

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1366,13 +1366,19 @@ func (portal *Portal) handleMatrixMediaDirect(url id.ContentURI, file *event.Enc
 		}
 	}
 
+	mimeType := mimetype.Detect(data).String()
+
+	// iMessage clients do not seem to understand a video is a video if the extension is missing.
+	if len(strings.Split(filename, ".")) == 1 && strings.HasPrefix(mimeType, "video/") {
+		filename = fmt.Sprintf("%s.%s", filename, mimeType[len("video/"):])
+	}
+	
 	var dir, filePath string
 	dir, filePath, err = imessage.SendFilePrepare(filename, data)
 	if err != nil {
 		portal.log.Errorfln("failed to prepare to send file: %w", err)
 		return
 	}
-	mimeType := mimetype.Detect(data).String()
 	isVoiceMemo := false
 	_, isMSC3245Voice := evt.Content.Raw["org.matrix.msc3245.voice"]
 


### PR DESCRIPTION
I'm running `mautrix-imessage` locally and noticed that when I send a video attachment from the Element iOS client, the video attachment arrives as an unknown file in the Messages app:

<img width="312" alt="image" src="https://github.com/mautrix/imessage/assets/1163192/03a0380d-b70b-438c-9b04-f92fc1b0eca3">

It would appear this is happening because the file is simply called `Video` without an extension. You would think the mime type would be enough to infer that, but I guess not ¯\\_ (ツ)_/¯

This PR fixes it by adding the (probable) extension based on the mime type to correct the issue.