### PR TITLE
Bot Commands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -64,7 +64,12 @@ var cmdStartDm = &commands.FullHandler{
 func fnStartDm(ce *WrappedCommandEvent) {
 	ce.Bridge.ZLog.Trace().Interface("args", ce.Args).Str("cmd", ce.Command).Msg("fnStartDm")
 
-	_, err := ce.Bridge.WebsocketHandler.StartChat(*&StartDMRequest{
+	if len(ce.Args) == 0 {
+		ce.Reply("**Usage:** `start-dm <international phone number>` OR `start-dm <apple id email address>`")
+		return
+	}
+
+	startedDm, err := ce.Bridge.WebsocketHandler.StartChat(*&StartDMRequest{
 		Identifier:    ce.RawArgs,
 		Force:         false,
 		ActuallyStart: true,
@@ -73,7 +78,7 @@ func fnStartDm(ce *WrappedCommandEvent) {
 	if err != nil {
 		ce.Reply("Failed to start DM: %s", err)
 	} else {
-		ce.Reply("Created!")
+		ce.Reply("Created portal room [%s](%s) and invited you to it.", startedDm.RoomID, startedDm.RoomID.URI(ce.Bridge.Config.Homeserver.Domain).MatrixToURL())
 	}
 }
 

--- a/commands.go
+++ b/commands.go
@@ -34,7 +34,7 @@ type WrappedCommandEvent struct {
 func (br *IMBridge) RegisterCommands() {
 	proc := br.CommandProcessor.(*commands.Processor)
 	proc.AddHandlers(
-		cmdStartDm,
+		cmdPM,
 	)
 }
 
@@ -50,22 +50,22 @@ func wrapCommand(handler func(*WrappedCommandEvent)) func(*commands.Event) {
 	}
 }
 
-var cmdStartDm = &commands.FullHandler{
-	Func: wrapCommand(fnStartDm),
-	Name: "start-dm",
+var cmdPM = &commands.FullHandler{
+	Func: wrapCommand(fnPM),
+	Name: "pm",
 	Help: commands.HelpMeta{
 		Section:     HelpSectionChatManagement,
-		Description: "Creates a new DM with the specified number.",
+		Description: "Creates a new PM with the specified number or address.",
 	},
 	RequiresPortal: false,
 	RequiresLogin:  false,
 }
 
-func fnStartDm(ce *WrappedCommandEvent) {
-	ce.Bridge.ZLog.Trace().Interface("args", ce.Args).Str("cmd", ce.Command).Msg("fnStartDm")
+func fnPM(ce *WrappedCommandEvent) {
+	ce.Bridge.ZLog.Trace().Interface("args", ce.Args).Str("cmd", ce.Command).Msg("fnPM")
 
 	if len(ce.Args) == 0 {
-		ce.Reply("**Usage:** `start-dm <international phone number>` OR `start-dm <apple id email address>`")
+		ce.Reply("**Usage:** `pm <international phone number>` OR `pm <apple id email address>`")
 		return
 	}
 
@@ -76,7 +76,7 @@ func fnStartDm(ce *WrappedCommandEvent) {
 	})
 
 	if err != nil {
-		ce.Reply("Failed to start DM: %s", err)
+		ce.Reply("Failed to start PM: %s", err)
 	} else {
 		ce.Reply("Created portal room [%s](%s) and invited you to it.", startedDm.RoomID, startedDm.RoomID.URI(ce.Bridge.Config.Homeserver.Domain).MatrixToURL())
 	}

--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,82 @@
+// mautrix-imessage - A Matrix-iMessage puppeting bridge.
+// Copyright (C) 2022 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"maunium.net/go/mautrix/bridge/commands"
+)
+
+var (
+	HelpSectionChatManagement = commands.HelpSection{Name: "Chat management", Order: 11}
+)
+
+type WrappedCommandEvent struct {
+	*commands.Event
+	Bridge *IMBridge
+	User   *User
+	Portal *Portal
+}
+
+func (br *IMBridge) RegisterCommands() {
+	proc := br.CommandProcessor.(*commands.Processor)
+	proc.AddHandlers(
+		cmdStartDm,
+	)
+}
+
+func wrapCommand(handler func(*WrappedCommandEvent)) func(*commands.Event) {
+	return func(ce *commands.Event) {
+		user := ce.User.(*User)
+		var portal *Portal
+		if ce.Portal != nil {
+			portal = ce.Portal.(*Portal)
+		}
+		br := ce.Bridge.Child.(*IMBridge)
+		handler(&WrappedCommandEvent{ce, br, user, portal})
+	}
+}
+
+var cmdStartDm = &commands.FullHandler{
+	Func: wrapCommand(fnStartDm),
+	Name: "start-dm",
+	Help: commands.HelpMeta{
+		Section:     HelpSectionChatManagement,
+		Description: "Creates a new DM with the specified number.",
+	},
+	RequiresPortal: false,
+	RequiresLogin:  false,
+}
+
+func fnStartDm(ce *WrappedCommandEvent) {
+	ce.Bridge.ZLog.Trace().Interface("args", ce.Args).Str("cmd", ce.Command).Msg("fnStartDm")
+
+	_, err := ce.Bridge.WebsocketHandler.StartChat(*&StartDMRequest{
+		Identifier:    ce.RawArgs,
+		Force:         false,
+		ActuallyStart: true,
+	})
+
+	if err != nil {
+		ce.Reply("Failed to start DM: %s", err)
+	} else {
+		ce.Reply("Created!")
+	}
+}
+
+// TODO: potentially add the following commands
+// contact-search (search contact for addresses so they can be used to start a dm)
+// start-group-chat

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
+github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/strukturag/libheif v1.17.6 h1:UFz4FI7kKLINWyL7bcNEBu4gZxK7rHRkwq49IOzHyvE=
 github.com/strukturag/libheif v1.17.6/go.mod h1:E/PNRlmVtrtj9j2AvBZlrO4dsBDu6KfwDZn7X1Ce8Ks=

--- a/imessage/bluebubbles/api.go
+++ b/imessage/bluebubbles/api.go
@@ -1037,12 +1037,18 @@ func (bb *blueBubbles) SendTypingNotification(chatID string, typing bool) error 
 
 func (bb *blueBubbles) ResolveIdentifier(identifier string) (string, error) {
 	bb.log.Trace().Str("identifier", identifier).Msg("ResolveIdentifier")
-	return "", ErrNotImplemented
+
+	// if the identifier is a phone number, remove dashes and prepend the +
+	if !strings.Contains(identifier, "@") {
+		identifier = "+" + numericOnly(identifier)
+	}
+
+	return "iMessage;-;" + identifier, nil
 }
 
 func (bb *blueBubbles) PrepareDM(guid string) error {
 	bb.log.Trace().Str("guid", guid).Msg("PrepareDM")
-	return ErrNotImplemented
+	return nil
 }
 
 func (bb *blueBubbles) CreateGroup(users []string) (*imessage.CreateGroupResponse, error) {

--- a/imessage/interface.go
+++ b/imessage/interface.go
@@ -38,6 +38,7 @@ var (
 type ContactAPI interface {
 	GetContactInfo(identifier string) (*Contact, error)
 	GetContactList() ([]*Contact, error)
+	SearchContactList(searchTerms string) ([]*Contact, error)
 }
 
 type ChatInfoAPI interface {

--- a/imessage/ios/ipc.go
+++ b/imessage/ios/ipc.go
@@ -19,6 +19,7 @@ package ios
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"os"
 	"strings"
@@ -474,6 +475,10 @@ func (ios *iOSConnector) GetContactList() ([]*imessage.Contact, error) {
 	var resp GetContactListResponse
 	err := ios.IPC.Request(context.Background(), ReqGetContactList, nil, &resp)
 	return resp.Contacts, err
+}
+
+func (ios *iOSConnector) SearchContactList(searchTerms string) ([]*imessage.Contact, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (ios *iOSConnector) GetChatInfo(chatID, threadID string) (*imessage.ChatInfo, error) {

--- a/imessage/mac-nosip/nosip.go
+++ b/imessage/mac-nosip/nosip.go
@@ -67,6 +67,10 @@ func (n NoopContacts) GetContactList() ([]*imessage.Contact, error) {
 	return []*imessage.Contact{}, nil
 }
 
+func (n NoopContacts) SearchContactList(searchTerms string) ([]*imessage.Contact, error) {
+	return nil, errors.New("not implemented")
+}
+
 func NewMacNoSIPConnector(bridge imessage.Bridge) (imessage.API, error) {
 	logger := bridge.GetLog().Sub("iMessage").Sub("Mac-noSIP")
 	processLogger := bridge.GetLog().Sub("iMessage").Sub("Barcelona")

--- a/imessage/mac/contacts.go
+++ b/imessage/mac/contacts.go
@@ -22,6 +22,7 @@ package mac
 //#include "meowMemory.h"
 import "C"
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -157,4 +158,8 @@ func (cs *ContactStore) GetContactList() ([]*imessage.Contact, error) {
 	runtime.UnlockOSThread()
 
 	return contacts, nil
+}
+
+func (cs ContactStore) SearchContactList(searchTerms string) ([]*imessage.Contact, error) {
+	return nil, errors.New("not implemented")
 }

--- a/main.go
+++ b/main.go
@@ -229,6 +229,9 @@ func (br *IMBridge) Init() {
 	br.IMHandler = NewiMessageHandler(br)
 	br.WebsocketHandler = NewWebsocketCommandHandler(br)
 	br.wsOnConnectWait.Add(1)
+
+	br.CommandProcessor = commands.NewProcessor(&br.Bridge)
+	br.RegisterCommands()
 }
 
 type PingResponse struct {


### PR DESCRIPTION
Adds bot commands for interacting with the bridge.
- `pm <phone or email>` will create a new "portal" (or chat in my layman's terms) 
  - this probably works with applescript and barcelona too, although untested)
- `search-contact <partial name, phone, or email>` will "fuzzy" search through contacts and spit out matches with names, numbers, and emails to make it easier to use the `pm` command above (you don't need to know the number ahead of time)
  - this is just going to spit out a `not implemented` message if used with applescript or barcelona)