### PR TITLE
adding retry timer

### DIFF
--- a/imessage/bluebubbles/api.go
+++ b/imessage/bluebubbles/api.go
@@ -137,7 +137,7 @@ func (bb *blueBubbles) PollForWebsocketMessages() {
 	// Initialize retry count
 	retryCount := 0
 	// Maximum retry count
-	const maxRetryCount = 5
+	const maxRetryCount = 2
 	for {
 		_, payload, err := bb.ws.ReadMessage()
 		if err != nil {
@@ -165,10 +165,8 @@ func (bb *blueBubbles) PollForWebsocketMessages() {
 					bb.log.Error().Msg("Maximum retry attempts reached, stopping reconnection attempts. Outer loop.")
 					break
 				}
-				bb.log.Error().Msg("Not reached part 1.")
 				continue
 			}
-			bb.log.Error().Msg("Not reached part 2.")
 			break
 		}
 

--- a/imessage/bluebubbles/api.go
+++ b/imessage/bluebubbles/api.go
@@ -147,7 +147,7 @@ func (bb *blueBubbles) PollForWebsocketMessages() {
 					bb.ws, err = bb.connectToWebSocket()
 					if err != nil {
 						if retryCount >= maxRetryCount {
-							bb.log.Error().Err(err).Msg("Maximum retry attempts reached, stopping reconnection attempts. Inner loop.")
+							bb.log.Error().Msg("Maximum retry attempts reached, stopping reconnection attempts. Inner loop.")
 							break
 						}
 						retryCount++

--- a/imessage/bluebubbles/api.go
+++ b/imessage/bluebubbles/api.go
@@ -147,7 +147,7 @@ func (bb *blueBubbles) PollForWebsocketMessages() {
 					bb.ws, err = bb.connectToWebSocket()
 					if err != nil {
 						if retryCount >= maxRetryCount {
-							bb.log.Error().Msg("Maximum retry attempts reached, stopping reconnection attempts. Inner loop.")
+							bb.log.Error().Err(err).Msg("Maximum retry attempts reached, stopping reconnection attempts. Inner loop.")
 							break
 						}
 						retryCount++

--- a/imessage/bluebubbles/api.go
+++ b/imessage/bluebubbles/api.go
@@ -111,6 +111,7 @@ func (bb *blueBubbles) Stop() {
 	bb.log.Trace().Msg("Stop")
 	bb.ws.WriteMessage(websocket.CloseMessage, []byte{})
 }
+
 func (bb *blueBubbles) connectToWebSocket() (*websocket.Conn, error) {
 	ws, _, err := websocket.DefaultDialer.Dial(bb.wsUrl(), nil)
 	if err != nil {
@@ -145,8 +146,8 @@ func (bb *blueBubbles) PollForWebsocketMessages() {
 				for {
 					bb.ws, err = bb.connectToWebSocket()
 					if err != nil {
-						if retryCount > maxRetryCount {
-							bb.log.Error().Msg("Maximum retry attempts reached, stopping reconnection attempts")
+						if retryCount >= maxRetryCount {
+							bb.log.Error().Msg("Maximum retry attempts reached, stopping reconnection attempts. Inner loop.")
 							break
 						}
 						retryCount++
@@ -160,8 +161,14 @@ func (bb *blueBubbles) PollForWebsocketMessages() {
 						break
 					}
 				}
+				if retryCount >= maxRetryCount {
+					bb.log.Error().Msg("Maximum retry attempts reached, stopping reconnection attempts. Outer loop.")
+					break
+				}
+				bb.log.Error().Msg("Not reached part 1.")
 				continue
 			}
+			bb.log.Error().Msg("Not reached part 2.")
 			break
 		}
 


### PR DESCRIPTION
isolated websocket into its own function
added a retry var that increases exponentially for each unexpected failure
Sleeping log message could be removed, it's in there for debugging at the moment.

**Questions**
- should we add a max number of retries?
- do we want the max retries to come from our config?
- does the outer loop also need to check the number of retry attempts?
- merge new function w/ `Start()` or keep them separate?

https://github.com/mautrix/imessage/pull/187#discussion_r1492992780

**Testing plan**
- [x] close bb and observe the sleep log
- [x] close bb and observe the reconnection occurring
- [x] close bb then reopen it after a few retries
- [x] close bb and wait out the max retry attempts