### PR TITLE
Fix backfilling

### DIFF
--- a/imessage/bluebubbles/interface.go
+++ b/imessage/bluebubbles/interface.go
@@ -17,8 +17,9 @@ const (
 type MessageQueryRequest struct {
 	// TODO Other Fields
 	ChatGUID string             `json:"chatGuid"`
-	Limit    int64              `json:"limit"`
-	Offset   int64              `json:"offset"`
+	Limit    int                `json:"limit"`
+	Max      *int               `json:"max"`
+	Offset   int                `json:"offset"`
 	With     []MessageQueryWith `json:"with"`
 	Sort     MessageQuerySort   `json:"sort"`
 	Before   *int64             `json:"before,omitempty"`
@@ -33,6 +34,9 @@ const (
 	MessageQueryWithAttachment       ChatQueryWith = "attachment"
 	MessageQueryWithHandle           ChatQueryWith = "handle"
 	MessageQueryWithSMS              ChatQueryWith = "sms"
+	MessageQueryWithAttributeBody    ChatQueryWith = "message.attributedBody"
+	MessageQueryWithMessageSummary   ChatQueryWith = "message.messageSummaryInfo"
+	MessageQueryWithPayloadData      ChatQueryWith = "message.payloadData"
 )
 
 type MessageQueryResponse struct {


### PR DESCRIPTION
BlueBubbles wasn't honoring the chatId filter used on the query messages endpoint so it was returning messages from all chats during the backfill process. I swapped the endpoint for the /chat/[chat id]/messages endpoint and updated the query with the proper params to account for the change. Notably, BlueBubbles has a maximum limit of 1000 messages, so the query function has also been updated accordingly. 

Before anyone wonders, no, this still does not backfill tapbacks. That code doesn't appear to exist in the [original bridge](https://github.com/mautrix/imessage/blob/ea7aebded1980512170b646d06a36ec3f5ffd07a/historysync.go#L165C1-L169C4):
```golang
        if msg.Tapback != nil {
            // TODO handle tapbacks
            portal.log.Debugln("Skipping tapback", msg.GUID, "in backfill")
            continue
        }
```