### PR TITLE
Backfill Tapbacks/Reactions & BlueBubbles Fix for Removing a Reaction

### DIFF
--- a/historysync.go
+++ b/historysync.go
@@ -154,13 +154,12 @@ func (portal *Portal) convertBackfill(messages []*imessage.Message) ([]*event.Ev
 	var lastMessage *imessage.Message
 	for _, msg := range messages {
 		if msg.Tapback != nil {
-			portal.log.Debugln("Skipping tapback", msg.GUID, "in backfill, handling later")
 			continue
 		}
 
 		//Skip the last message in the array, we will add it later to correct inbox sorting
 		if msg == messages[len(messages)-1] && len(messages) > 1 /* we call this function again with one element in the array for the last message, so we'll want to process it */ {
-			portal.log.Errorln("Skipping message", msg.GUID, "in backfill, last one in the convo")
+			portal.log.Debugln("Skipping message", msg.GUID, "in backfill, last one in the convo")
 			lastMessage = msg
 			continue
 		}
@@ -206,13 +205,12 @@ func (portal *Portal) convertTapbacks(messages []*imessage.Message) ([]*event.Ev
 	for _, msg := range messages {
 		//Only want tapbacks
 		if msg.Tapback == nil {
-			portal.log.Debugln("Skipping message", msg.GUID, "in backfill, should've already handled")
 			continue
 		}
 
 		//Skip the last message in the array, we will add it later to correct inbox sorting
 		if msg == messages[len(messages)-1] && len(messages) > 1 /* we call this function again with one element in the array for the last message, so we'll want to process it */ {
-			portal.log.Errorln("Skipping message", msg.GUID, "in backfill, last one in the convo")
+			portal.log.Debugln("Skipping message", msg.GUID, "in backfill, last one in the convo")
 			lastMessage = msg
 			continue
 		}

--- a/historysync.go
+++ b/historysync.go
@@ -210,11 +210,6 @@ func (portal *Portal) convertTapbacks(messages []*imessage.Message) ([]*event.Ev
 			continue
 		}
 
-		//If we don't process it, there won't be a reaction; at least for BB, we never have to remove a reaction
-		if msg.Tapback.Remove {
-			continue
-		}
-
 		//Skip the last message in the array, we will add it later to correct inbox sorting
 		if msg == messages[len(messages)-1] && len(messages) > 1 /* we call this function again with one element in the array for the last message, so we'll want to process it */ {
 			portal.log.Errorln("Skipping message", msg.GUID, "in backfill, last one in the convo")
@@ -289,6 +284,13 @@ func (portal *Portal) sendBackfill(backfillID string, messages []*imessage.Messa
 		if intent == nil {
 			portal.log.Debugln("Skipping", msg.GUID, "in backfill (didn't get an intent)")
 			continue
+		}
+		if msg.Tapback != nil && msg.Tapback.Remove {
+			//If we don't process it, there won't be a reaction; at least for BB, we never have to remove a reaction
+			if msg.Tapback.Remove {
+				portal.log.Debugln("Skipping", msg.GUID, "in backfill (it was a remove tapback)")
+				continue
+			}
 		}
 
 		validMessages = append(validMessages, msg)

--- a/historysync.go
+++ b/historysync.go
@@ -264,10 +264,8 @@ func (portal *Portal) sendBackfill(backfillID string, messages []*imessage.Messa
 		}
 		if msg.Tapback != nil && msg.Tapback.Remove {
 			//If we don't process it, there won't be a reaction; at least for BB, we never have to remove a reaction
-			if msg.Tapback.Remove {
-				portal.log.Debugln("Skipping", msg.GUID, "in backfill (it was a remove tapback)")
-				continue
-			}
+			portal.log.Debugln("Skipping", msg.GUID, "in backfill (it was a remove tapback)")
+			continue
 		}
 
 		validMessages = append(validMessages, msg)

--- a/historysync.go
+++ b/historysync.go
@@ -215,6 +215,10 @@ func (portal *Portal) convertTapbacks(messages []*imessage.Message) ([]*event.Ev
 			continue
 		}
 
+		if msg.Tapback.Remove {
+			continue
+		}
+
 		dbMessage := portal.bridge.DB.Message.GetByGUID(portal.GUID, msg.Tapback.TargetGUID, msg.Tapback.TargetPart)
 		if dbMessage == nil {
 			//TODO BUG: This occurs when trying to find the target reaction for a rich link, related to #183
@@ -386,6 +390,9 @@ func (portal *Portal) sendBackfillToMatrixServer(batchSending, forward, forwardI
 func (portal *Portal) finishBackfill(txn dbutil.Transaction, eventIDs []id.EventID, metas []messageWithIndex) {
 	for i, info := range metas {
 		if info.Tapback != nil {
+			if info.Tapback.Remove {
+				continue
+			}
 			dbTapback := portal.bridge.DB.Tapback.New()
 			dbTapback.PortalGUID = portal.GUID
 			dbTapback.SenderGUID = info.Sender.String()

--- a/imessage/bluebubbles/api.go
+++ b/imessage/bluebubbles/api.go
@@ -1716,10 +1716,10 @@ func (bb *blueBubbles) convertBBMessageToiMessage(bbMessage Message) (*imessage.
 func (bb *blueBubbles) convertBBTapbackToImessageTapback(associatedMessageType string) (tbType imessage.TapbackType) {
 	if strings.Contains(associatedMessageType, "love") {
 		tbType = imessage.TapbackLove
-	} else if strings.Contains(associatedMessageType, "like") {
-		tbType = imessage.TapbackLike
 	} else if strings.Contains(associatedMessageType, "dislike") {
 		tbType = imessage.TapbackDislike
+	} else if strings.Contains(associatedMessageType, "like") {
+		tbType = imessage.TapbackLike
 	} else if strings.Contains(associatedMessageType, "laugh") {
 		tbType = imessage.TapbackLaugh
 	} else if strings.Contains(associatedMessageType, "emphasize") {

--- a/imessage/bluebubbles/api.go
+++ b/imessage/bluebubbles/api.go
@@ -1678,7 +1678,7 @@ func (bb *blueBubbles) convertBBMessageToiMessage(bbMessage Message) (*imessage.
 		bbMessage.AssociatedMessageType != "" {
 		message.Tapback = &imessage.Tapback{
 			TargetGUID: bbMessage.AssociatedMessageGUID,
-			Type:       imessage.TapbackFromName(bbMessage.AssociatedMessageType),
+			Type:       bb.convertBBTapbackToImessageTapback(bbMessage.AssociatedMessageType),
 		}
 		message.Tapback.Parse()
 	} else {
@@ -1711,6 +1711,27 @@ func (bb *blueBubbles) convertBBMessageToiMessage(bbMessage Message) (*imessage.
 	message.ThreadID = bbMessage.ThreadOriginatorGUID
 
 	return &message, nil
+}
+
+func (bb *blueBubbles) convertBBTapbackToImessageTapback(associatedMessageType string) (tbType imessage.TapbackType) {
+	if strings.Contains(associatedMessageType, "love") {
+		tbType = imessage.TapbackLove
+	} else if strings.Contains(associatedMessageType, "like") {
+		tbType = imessage.TapbackLike
+	} else if strings.Contains(associatedMessageType, "dislike") {
+		tbType = imessage.TapbackDislike
+	} else if strings.Contains(associatedMessageType, "laugh") {
+		tbType = imessage.TapbackLaugh
+	} else if strings.Contains(associatedMessageType, "emphasize") {
+		tbType = imessage.TapbackEmphasis
+	} else if strings.Contains(associatedMessageType, "question") {
+		tbType = imessage.TapbackQuestion
+	}
+
+	if strings.Contains(associatedMessageType, "-") {
+		tbType += imessage.TapbackRemoveOffset
+	}
+	return tbType
 }
 
 func (bb *blueBubbles) convertBBChatToiMessageChat(bbChat Chat) (*imessage.ChatInfo, error) {


### PR DESCRIPTION
Resolves #185 

Creates reaction events and sends them to the Matrix server and database after all other messages are sent. The other messages are required to be sent before reactions because reaction events need the event ID of the original message in order to be sent, which is only acquired by sending the target message first. Sending events to the Matrix server was moved to its own function because it now needs to be done twice. There is a case where reaction events fail to be created because we are unable to lookup the event ID of the link in a rich link (as rich links have double the reactions as normal messages, one for the favicon and the other for the link, see #183).

Note: This has only been tested for BlueBubbles, if someone could test this with the other connecters it would be much appreciated. There seemed to be a concern that removed reactions would need to be handled differently ~~but BB doesn't keep track of removed reactions when querying because the reaction no longer exists~~ (it does but prefixes it with a dash).

This PR also fixes removing a reaction for BB. Previously, the connector would send and handle the removal of reactions correctly but would add a reaction of an empty string to messages when the connector would get the updated message event. This is because the string passed in for TapbackFromName strictly matched the string and didn't handle the "-" that BB would prefix the reaction.