### PR TITLE
Allow double puppeting with isolated appservice registration

### DIFF
--- a/custompuppet.go
+++ b/custompuppet.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/appservice"
@@ -85,6 +86,9 @@ func (user *User) loginWithSharedSecret() error {
 	}
 	if loginSecret == "appservice" {
 		client.AccessToken = user.bridge.AS.Registration.AppToken
+		req.Type = mautrix.AuthTypeAppservice
+	} else if strings.HasPrefix(loginSecret, "as_token:") {
+		client.AccessToken = loginSecret[9:]
 		req.Type = mautrix.AuthTypeAppservice
 	} else {
 		mac := hmac.New(sha512.New, []byte(loginSecret))

--- a/portal.go
+++ b/portal.go
@@ -1413,8 +1413,10 @@ func (portal *Portal) handleMatrixMediaDirect(url id.ContentURI, file *event.Enc
 	// Only convert when sending to iMessage. SMS users probably don't want CAF.
 	if portal.Identifier.Service == "iMessage" && isMSC3245Voice && strings.HasPrefix(mimeType, "audio/") {
 		cafPath := strings.TrimSuffix(filePath, filepath.Ext(filePath)) + ".caf"
-		if err = exec.Command("afconvert", "-f", "caff", "-d", "opus", filePath, cafPath).Run(); err != nil {
-			log.Errorfln("Failed to transcode voice message to CAF. Error: %w", err)
+		cmd := exec.Command("afconvert", "-f", "caff", "-d", "opus", filePath, cafPath)
+		if out, convErr := cmd.CombinedOutput(); convErr != nil {
+			log.Errorfln("Failed to transcode voice message to CAF: %v\nafconvert output: %s", convErr, out)
+			err = convErr
 			return
 		}
 		filePath = cafPath

--- a/portal.go
+++ b/portal.go
@@ -1412,10 +1412,18 @@ func (portal *Portal) handleMatrixMediaDirect(url id.ContentURI, file *event.Enc
 
 	// Only convert when sending to iMessage. SMS users probably don't want CAF.
 	if portal.Identifier.Service == "iMessage" && isMSC3245Voice && strings.HasPrefix(mimeType, "audio/") {
-		cafPath := strings.TrimSuffix(filePath, filepath.Ext(filePath)) + ".caf"
-		cmd := exec.Command("afconvert", "-f", "caff", "-d", "opus", filePath, cafPath)
-		if out, convErr := cmd.CombinedOutput(); convErr != nil {
-			log.Errorfln("Failed to transcode voice message to CAF: %v\nafconvert output: %s", convErr, out)
+		basePath := strings.TrimSuffix(filePath, filepath.Ext(filePath))
+		aiffPath := basePath + ".aiff"
+		cafPath := basePath + ".caf"
+		// ffmpeg decodes OGG/Opus (which afconvert cannot read) to AIFF
+		if out, convErr := exec.Command("ffmpeg", "-i", filePath, "-f", "aiff", aiffPath).CombinedOutput(); convErr != nil {
+			log.Errorfln("Failed to decode voice message to AIFF: %v\nffmpeg output: %s", convErr, out)
+			err = convErr
+			return
+		}
+		// afconvert encodes AIFF -> CAF/AAC (the standard format for iMessage voice memos)
+		if out, convErr := exec.Command("afconvert", "-f", "caff", "-d", "aac", aiffPath, cafPath).CombinedOutput(); convErr != nil {
+			log.Errorfln("Failed to encode voice message to CAF: %v\nafconvert output: %s", convErr, out)
 			err = convErr
 			return
 		}

--- a/portal.go
+++ b/portal.go
@@ -1411,19 +1411,21 @@ func (portal *Portal) handleMatrixMediaDirect(url id.ContentURI, file *event.Enc
 	_, isMSC3245Voice := evt.Content.Raw["org.matrix.msc3245.voice"]
 
 	// Only convert when sending to iMessage. SMS users probably don't want CAF.
+	// iMessage voice memos use CAF with Opus codec at 24000 Hz (since iOS 12.2).
+	// ffmpeg cannot mux Opus into CAF, so we use a two-stage conversion:
+	// 1. ffmpeg decodes OGG to AIFF (afconvert cannot read OGG)
+	// 2. afconvert encodes AIFF to CAF/Opus
 	if portal.Identifier.Service == "iMessage" && isMSC3245Voice && strings.HasPrefix(mimeType, "audio/") {
 		basePath := strings.TrimSuffix(filePath, filepath.Ext(filePath))
 		aiffPath := basePath + ".aiff"
 		cafPath := basePath + ".caf"
-		// ffmpeg decodes OGG/Opus (which afconvert cannot read) to AIFF
 		if out, convErr := exec.Command("ffmpeg", "-i", filePath, "-f", "aiff", aiffPath).CombinedOutput(); convErr != nil {
 			log.Errorfln("Failed to decode voice message to AIFF: %v\nffmpeg output: %s", convErr, out)
 			err = convErr
 			return
 		}
-		// afconvert encodes AIFF -> CAF/AAC (the standard format for iMessage voice memos)
-		if out, convErr := exec.Command("afconvert", "-f", "caff", "-d", "aac", aiffPath, cafPath).CombinedOutput(); convErr != nil {
-			log.Errorfln("Failed to encode voice message to CAF: %v\nafconvert output: %s", convErr, out)
+		if out, convErr := exec.Command("afconvert", "-f", "caff", "-d", "opus", aiffPath, cafPath).CombinedOutput(); convErr != nil {
+			log.Errorfln("Failed to encode voice message to CAF/Opus: %v\nafconvert output: %s", convErr, out)
 			err = convErr
 			return
 		}

--- a/portal.go
+++ b/portal.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"runtime/debug"
 	"sort"
@@ -1411,15 +1412,15 @@ func (portal *Portal) handleMatrixMediaDirect(url id.ContentURI, file *event.Enc
 
 	// Only convert when sending to iMessage. SMS users probably don't want CAF.
 	if portal.Identifier.Service == "iMessage" && isMSC3245Voice && strings.HasPrefix(mimeType, "audio/") {
-		filePath, err = ffmpeg.ConvertPath(context.TODO(), filePath, ".caf", []string{}, []string{"-c:a", "libopus"}, false)
-		mimeType = "audio/x-caf"
-		isVoiceMemo = true
-		filename = filepath.Base(filePath)
-
-		if err != nil {
+		cafPath := strings.TrimSuffix(filePath, filepath.Ext(filePath)) + ".caf"
+		if err = exec.Command("afconvert", "-f", "caff", "-d", "opus", filePath, cafPath).Run(); err != nil {
 			log.Errorfln("Failed to transcode voice message to CAF. Error: %w", err)
 			return
 		}
+		filePath = cafPath
+		mimeType = "audio/x-caf"
+		isVoiceMemo = true
+		filename = filepath.Base(filePath)
 	}
 
 	resp, err = portal.bridge.IM.SendFile(portal.getTargetGUID("media message", evt.ID, ""), caption, filename, filePath, messageReplyID, messageReplyPart, mimeType, isVoiceMemo, metadata)


### PR DESCRIPTION
@tulir is this what you had in mind for allowing this bridge to support an isolated doublepuppet appservice?  Seems to work.