### PR TITLE
Update portal.go for macOS Tahoe

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1126,7 +1126,7 @@ func (portal *Portal) sendSuccessMessageStatus(eventID id.EventID, service, hand
 		Status: event.MessageStatusSuccess,
 	}
 
-	if !portal.Identifier.IsGroup && portal.Identifier.Service == "iMessage" && portal.bridge.IM.Capabilities().DeliveredStatus {
+	if !portal.Identifier.IsGroup && (portal.Identifier.Service == "iMessage" || portal.Identifier.Service == "any") && portal.bridge.IM.Capabilities().DeliveredStatus {
 		// This is an iMessage DM, then we want to include the list of users
 		// that the message has been delivered to.
 		mainContent.DeliveredToUsers = &deliveredTo


### PR DESCRIPTION

## Fix delivery receipts on macOS Tahoe (26)

### Problem

macOS Tahoe (26) changed the chat GUID format in the Messages database. Previously, DM chat GUIDs were formatted as:

```
iMessage;-;+1234567890
```

Tahoe now uses:

```
any;-;+1234567890
```

The `service_name` column still correctly contains `iMessage`, but the GUID prefix changed to `any`.

This caused the delivery status check on line 1129 to fail for iMessage DMs, resulting in Beeper/Matrix clients showing "Sent" instead of "Delivered".

### Fix

Accept `"any"` as a valid service type for iMessage DMs when determining whether to send delivery status events.

### Tested with

- macOS Tahoe 26.0
- BlueBubbles server with Private API enabled
- Beeper client